### PR TITLE
feat: 메인 페이지 및 이용약관 페이지 구현

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,10 +1,8 @@
-import Header from '@/components/layout/Header'
 import Image from 'next/image'
 
 export default function Page() {
   return (
     <div className="flex flex-col min-h-screen">
-      <Header />
       <div className="flex flex-col items-center justify-center flex-1 gap-6 px-10">
         <p className="text-center text-2xl font-bold leading-tight">
           나만의 <span className="text-blue-500">개발 스토리</span>를 담는{' '}

--- a/src/app/terms/page.tsx
+++ b/src/app/terms/page.tsx
@@ -1,0 +1,21 @@
+export default function TermsPage() {
+  return (
+    <div className="flex flex-col min-h-screen px-10 py-16 max-w-3xl mx-auto">
+      <h1 className="title-bold mb-8">이용 약관</h1>
+      <div className="flex flex-col gap-6 body-m">
+        <section>
+          <h2 className="title-sb-md mb-2">제1조 (목적)</h2>
+          <p>본 약관은 AutoPort 서비스 이용에 관한 조건 및 절차를 규정합니다.</p>
+        </section>
+        <section>
+          <h2 className="title-sb-md mb-2">제2조 (서비스 이용)</h2>
+          <p>서비스 이용자는 본 약관에 동의한 것으로 간주합니다.</p>
+        </section>
+        <section>
+          <h2 className="title-sb-md mb-2">제3조 (개인정보 보호)</h2>
+          <p>수집된 개인정보는 서비스 제공 목적 외에 사용되지 않습니다.</p>
+        </section>
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
## 📌 개요

- **관련 이슈**: #12
- **작업 요약**: 메인 페이지 및 이용약관 페이지 구현

---

## 🔍 주요 구현 내용

### 1. 기능 설명

- **메인 페이지 구현**: 서비스 소개 텍스트와 메인 이미지를 중앙 배치
- **이용약관 페이지 구현**: 이용약관 링크 클릭 시 이동하는 `/terms` 페이지 구현 (내용은 추후 업데이트 예정)

---

## 🤔 고민한 점 및 해결 과정

- 특이한 기술적 이슈 없이 구현 완료
 
---

## 📸 실행 결과 (이미지/GIF)

**[메인 페이지]**
<img width="1279" height="673" alt="image" src="https://github.com/user-attachments/assets/aff07133-0f42-41a2-b25e-cd23ab896c59" />


**[이용약관 페이지]**
<img width="1279" height="671" alt="image" src="https://github.com/user-attachments/assets/999612d2-1ada-4158-981a-5afacf4f1734" />

---

## 💡 리뷰어 전달 사항

- **집중해서 봐주었으면 하는 부분**: 이용약관 내용은 추후 업데이트 예정이므로 페이지 구조 위주로!
- **우려되는 부분**: 이미지를 피그마에 있는걸로 하나의 png로 저장해서 사용
- 와이어 프레임과 디자인의 차이가 있어 일단 디자인에 맞춰 구현함

- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 