### PR TITLE
feat: GitHub 로그인/회원가입 구현

### DIFF
--- a/src/app/auth/github/callback/page.tsx
+++ b/src/app/auth/github/callback/page.tsx
@@ -21,7 +21,7 @@ function GithubCallbackContent() {
       if (res.success) {
         if (res.data.isNewUser) {
           sessionStorage.setItem('tempUserId', res.data.tempUserId)
-          router.push('/auth/github')
+          router.push('/signup/info')
         } else {
           localStorage.setItem('accessToken', res.data.accessToken)
           router.push('/')

--- a/src/app/auth/github/callback/page.tsx
+++ b/src/app/auth/github/callback/page.tsx
@@ -1,0 +1,49 @@
+'use client'
+
+import { useEffect, Suspense } from 'react'
+import { useRouter, useSearchParams } from 'next/navigation'
+import { githubLogin } from '@/lib/api/auth'
+
+const REDIRECT_URI = `${process.env.NEXT_PUBLIC_FRONTEND_URL}/auth/github/callback`
+
+function GithubCallbackContent() {
+  const router = useRouter()
+  const searchParams = useSearchParams()
+
+  useEffect(() => {
+    const code = searchParams.get('code')
+    if (!code) {
+      router.push('/')
+      return
+    }
+
+    githubLogin({ code, redirectUri: REDIRECT_URI }).then((res) => {
+      if (res.success) {
+        if (res.data.isNewUser) {
+          sessionStorage.setItem('tempUserId', res.data.tempUserId)
+          router.push('/auth/github')
+        } else {
+          localStorage.setItem('accessToken', res.data.accessToken)
+          router.push('/')
+        }
+      } else {
+        alert('GitHub 로그인에 실패했습니다!')
+        router.push('/login')
+      }
+    })
+  }, [])
+
+  return (
+    <div className="flex flex-col items-center justify-center min-h-screen">
+      <p className="body-m">로그인 중...</p>
+    </div>
+  )
+}
+
+export default function GithubCallbackPage() {
+  return (
+    <Suspense>
+      <GithubCallbackContent />
+    </Suspense>
+  )
+}

--- a/src/app/auth/github/page.tsx
+++ b/src/app/auth/github/page.tsx
@@ -1,0 +1,5 @@
+import GithubSignupForm from '@/features/auth/components/GithubSignupForm'
+
+export default function GithubSignupPage() {
+  return <GithubSignupForm />
+}

--- a/src/features/auth/components/GithubSignupForm.tsx
+++ b/src/features/auth/components/GithubSignupForm.tsx
@@ -1,0 +1,58 @@
+'use client'
+
+import { useState } from 'react'
+import { useRouter } from 'next/navigation'
+import { oauthSignup } from '@/lib/api/auth'
+import FormInput from '@/components/ui/FormInput'
+
+export default function GithubSignupForm() {
+  const router = useRouter()
+  const [name, setName] = useState('')
+  const [bio, setBio] = useState('')
+
+  const handleSignup = async (e: React.FormEvent) => {
+    e.preventDefault()
+    const tempUserId = sessionStorage.getItem('tempUserId')
+    if (!tempUserId) {
+      alert('다시 시도해주세요!')
+      router.push('/signup')
+      return
+    }
+    const res = await oauthSignup({ tempUserId, name, bio })
+    if (res.success) {
+      sessionStorage.removeItem('tempUserId')
+      localStorage.setItem('accessToken', res.data.accessToken)
+      router.push('/signup/complete')
+    } else {
+      alert('회원가입에 실패했습니다!')
+    }
+  }
+
+  return (
+    <div className="flex flex-col min-h-screen">
+      <div className="flex flex-col items-center justify-center flex-1">
+        <h1 className="title-bold mb-8">추가 정보 입력</h1>
+        <form onSubmit={handleSignup} className="flex flex-col gap-4 w-80">
+          <FormInput
+            type="text"
+            placeholder="닉네임 (포트폴리오 이름)"
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+          />
+          <FormInput
+            type="text"
+            placeholder="한줄소개"
+            value={bio}
+            onChange={(e) => setBio(e.target.value)}
+          />
+          <button
+            type="submit"
+            className="bg-blue-500 text-white py-3 rounded-md body-m"
+          >
+            회원가입 완료
+          </button>
+        </form>
+      </div>
+    </div>
+  )
+}

--- a/src/features/auth/components/LoginPage.tsx
+++ b/src/features/auth/components/LoginPage.tsx
@@ -22,7 +22,9 @@ export default function LoginPage() {
   }
 
   const handleGithubLogin = () => {
-    // GitHub OAuth 연동 후 구현 예정
+    const clientId = process.env.NEXT_PUBLIC_GITHUB_CLIENT_ID
+    const redirectUri = `${process.env.NEXT_PUBLIC_FRONTEND_URL}/auth/github/callback`
+    window.location.href = `https://github.com/login/oauth/authorize?client_id=${clientId}&redirect_uri=${redirectUri}&scope=read:user`
   }
 
   return (

--- a/src/features/auth/components/SignupComplete.tsx
+++ b/src/features/auth/components/SignupComplete.tsx
@@ -10,7 +10,7 @@ export default function SignupComplete() {
     <div className="flex flex-col min-h-screen">
       <div className="flex flex-col items-center justify-center flex-1 gap-4">
         <h1 className="title-bold">회원가입이 완료되었습니다!</h1>
-        <Image src="/octopus.svg" alt="완료" width={400} height={400} />
+        <Image src="/octopus.svg" alt="" width={400} height={400} />
         <button
           onClick={() => router.push('/')}
           className="bg-blue-500 text-white py-3 px-6 rounded-md body-m"

--- a/src/features/auth/components/SignupSelectPage.tsx
+++ b/src/features/auth/components/SignupSelectPage.tsx
@@ -11,7 +11,7 @@ export default function SignupSelectPage() {
     <div className="flex flex-col min-h-screen">
       <div className="flex flex-col items-center justify-center flex-1">
         <section className="flex flex-col gap-4 w-80">
-          <h1 className="title-bold mb-8">회원가입</h1>
+          <h1 className="title-bold mb-8 text-center">회원가입</h1>
           <button
             onClick={() => window.location.href = '/signup/email'}
             className="bg-blue-500 text-white py-3 rounded-md body-m"

--- a/src/features/auth/components/SignupSelectPage.tsx
+++ b/src/features/auth/components/SignupSelectPage.tsx
@@ -1,9 +1,11 @@
 'use client'
 
-import { useRouter } from 'next/navigation'
-
 export default function SignupSelectPage() {
-  const router = useRouter()
+  const handleGithubAuth = () => {
+    const clientId = process.env.NEXT_PUBLIC_GITHUB_CLIENT_ID
+    const redirectUri = `${process.env.NEXT_PUBLIC_FRONTEND_URL}/auth/github/callback`
+    window.location.href = `https://github.com/login/oauth/authorize?client_id=${clientId}&redirect_uri=${redirectUri}&scope=read:user`
+  }
 
   return (
     <div className="flex flex-col min-h-screen">
@@ -11,13 +13,13 @@ export default function SignupSelectPage() {
         <section className="flex flex-col gap-4 w-80">
           <h1 className="title-bold mb-8">회원가입</h1>
           <button
-            onClick={() => router.push('/signup/email')}
+            onClick={() => window.location.href = '/signup/email'}
             className="bg-blue-500 text-white py-3 rounded-md body-m"
           >
             이메일로 회원가입
           </button>
           <button
-            onClick={() => router.push('/signup/github')}
+            onClick={handleGithubAuth}
             className="bg-gray-800 text-white py-3 rounded-md body-m flex items-center justify-center gap-2"
           >
             <svg width="20" height="20" viewBox="0 0 24 24" fill="white">

--- a/src/lib/api/auth.ts
+++ b/src/lib/api/auth.ts
@@ -48,3 +48,15 @@ export const oauthSignup = async (data: {
   })
   return res.json()
 }
+
+export const githubLogin = async (data: {
+  code: string
+  redirectUri: string
+}) => {
+  const res = await fetch(`${API_BASE_URL}/api/auth/github`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(data),
+  })
+  return res.json()
+}


### PR DESCRIPTION
## 📌 개요

- **관련 이슈**: #13
- **작업 요약**: GitHub 로그인/회원가입 콜백 페이지 구현

---

## 🔍 주요 구현 내용

### 1. 기능 설명

- **GitHub 회원가입**: GitHub 인증 후 신규 유저면 추가정보 입력 페이지(`/signup/info`)로 이동
- **GitHub 로그인**: GitHub 인증 후 기존 유저면 accessToken 저장 후 메인 페이지(`/`)로 이동

---

## 🤔 고민한 점 및 해결 과정

- **Issue**: 로컬 환경에서 GitHub OAuth callback URL 불일치로 400 에러 발생
- **Decision**: 배포 환경(`https://autoport-fe.vercel.app`)에서 테스트하는 방향으로 결정
- **Reason**: OAuth App callback URL이 배포 URL로 설정되어 있어 로컬 테스트보다 배포 환경 테스트가 적합

---

## 📸 실행 결과 (이미지/GIF)

> 테스트 코드 대신, 실제 동작하는 모습을 시각적으로 확인시켜 주세요.

| 구분             | 내용                                        |
| :--------------- | :------------------------------------------ |
| **스크린샷/GIF** |                                             |
| **동작 설명**    | GitHub 로그인/회원가입 버튼 클릭 시 GitHub 인증 후 콜백 처리, 신규 유저는 추가정보 입력 페이지로 이동 |

---

## 💡 리뷰어 전달 사항

- **집중해서 봐주었으면 하는 부분**: 
- **우려되는 부분**: 배포 환경에서만 테스트 가능하여 로컬 테스트 불가
