### PR TITLE
fix: GitHub 회원가입/로그인 버그 1차 수정

### DIFF
--- a/src/app/auth/github/callback/page.tsx
+++ b/src/app/auth/github/callback/page.tsx
@@ -20,9 +20,10 @@ function GithubCallbackContent() {
     githubLogin({ code, redirectUri: REDIRECT_URI }).then((res) => {
       if (res.success) {
         if (res.data.isNewUser) {
-          sessionStorage.setItem('tempUserId', res.data.tempUserId)
+          sessionStorage.setItem('tempUserId', String(res.data.tempUserId))
           router.push('/signup/info')
         } else {
+          sessionStorage.removeItem('tempUserId')
           localStorage.setItem('accessToken', res.data.accessToken)
           router.push('/')
         }
@@ -34,8 +35,9 @@ function GithubCallbackContent() {
   }, [])
 
   return (
-    <div className="flex flex-col items-center justify-center min-h-screen">
-      <p className="body-m">로그인 중...</p>
+    <div className="flex flex-col items-center justify-center min-h-screen gap-4">
+      <div className="w-8 h-8 border-4 border-blue-500 border-t-transparent rounded-full animate-spin" />
+      <p className="body-m">처리 중...</p>
     </div>
   )
 }

--- a/src/features/auth/components/GithubSignupForm.tsx
+++ b/src/features/auth/components/GithubSignupForm.tsx
@@ -18,7 +18,7 @@ export default function GithubSignupForm() {
       router.push('/signup')
       return
     }
-    const res = await oauthSignup({ tempUserId, name, bio })
+    const res = await oauthSignup({ tempUserId: Number(tempUserId), name, bio })
     if (res.success) {
       sessionStorage.removeItem('tempUserId')
       localStorage.setItem('accessToken', res.data.accessToken)

--- a/src/lib/api/auth.ts
+++ b/src/lib/api/auth.ts
@@ -37,7 +37,7 @@ export const localLogin = async (data: {
 }
 
 export const oauthSignup = async (data: {
-  tempUserId: string
+  tempUserId: number
   name: string
   bio: string
 }) => {


### PR DESCRIPTION
## 📌 개요
- **관련 이슈**: #13
- **작업 요약**: GitHub 회원가입/로그인 버그 수정

---
## 🔍 주요 구현 내용

### 1. 기능 설명
- **[tempUserId 타입 변환]**: 백엔드에서 number로 오는 tempUserId를 String()으로 변환해 sessionStorage에 저장, 추가정보 입력 시 Number()로 변환해 API 전송
- **[sessionStorage 정리]**: 기존 유저 로그인 시 sessionStorage의 tempUserId 삭제하여 추가정보 페이지로 잘못 이동하는 버그 수정

---
## 🤔 고민한 점 및 해결 과정
- **Issue**: sessionStorage는 문자열만 저장되는데 tempUserId가 숫자로 와서 타입 불일치 발생
- **Decision**: 저장 시 String(), 전송 시 Number()로 변환
- **Reason**: sessionStorage 특성상 문자열 변환이 필요하고, API는 number 타입을 요구하기 때문

---
## 💡 리뷰어 전달 사항
- **우려되는 부분**: 백엔드 `/api/auth/signup/github` 500 에러로 GitHub 회원가입 완료가 아직 안 됨