### PR TITLE
fix: GitHub 회원가입/로그인 버그 2차 수정

### DIFF
--- a/src/features/auth/components/AdditionalInfoForm.tsx
+++ b/src/features/auth/components/AdditionalInfoForm.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from 'react'
 import { useRouter } from 'next/navigation'
-import { emailSignup } from '@/lib/api/auth'
+import { emailSignup, oauthSignup } from '@/lib/api/auth'
 import FormInput from '@/components/ui/FormInput'
 
 export default function AdditionalInfoForm() {
@@ -12,19 +12,35 @@ export default function AdditionalInfoForm() {
 
   const handleSignup = async (e: React.FormEvent) => {
     e.preventDefault()
-    const saved = sessionStorage.getItem('signupData')
-    if (!saved) {
-      alert('다시 시도해주세요!')
-      router.push('/signup/email')
-      return
-    }
-    const { email, password, code } = JSON.parse(saved)
-    const res = await emailSignup({ email, password, name, bio, code })
-    if (res.success) {
-      sessionStorage.removeItem('signupData')
-      router.push('/signup/complete')
+
+    const tempUserId = sessionStorage.getItem('tempUserId')
+
+    if (tempUserId) {
+      // GitHub 회원가입
+      const res = await oauthSignup({ tempUserId: Number(tempUserId), name, bio })
+      if (res.success) {
+        sessionStorage.removeItem('tempUserId')
+        localStorage.setItem('accessToken', res.data.accessToken)
+        router.push('/signup/complete')
+      } else {
+        alert('회원가입에 실패했습니다!')
+      }
     } else {
-      alert('회원가입에 실패했습니다!')
+      // 일반 회원가입
+      const saved = sessionStorage.getItem('signupData')
+      if (!saved) {
+        alert('다시 시도해주세요!')
+        router.push('/signup/email')
+        return
+      }
+      const { email, password, code } = JSON.parse(saved)
+      const res = await emailSignup({ email, password, name, bio, code })
+      if (res.success) {
+        sessionStorage.removeItem('signupData')
+        router.push('/signup/complete')
+      } else {
+        alert('회원가입에 실패했습니다!')
+      }
     }
   }
 


### PR DESCRIPTION
## 📌 개요
- **관련 이슈**: #13
- **작업 요약**: 추가정보 입력 페이지에서 GitHub/이메일 회원가입 분기 처리

---
## 🔍 주요 구현 내용

### 1. 기능 설명
- **[회원가입 분기 처리]**: `/signup/info` 페이지에서 `tempUserId` 유무로 GitHub/이메일 회원가입 구분
  - `tempUserId` 있으면 → GitHub 회원가입 (`/api/auth/signup/github`)
  - `tempUserId` 없으면 → 이메일 회원가입 (`/api/auth/signup`)

### 2. 핵심 코드/로직
- `AdditionalInfoForm.tsx` 에서 sessionStorage의 `tempUserId` 확인 후 분기 처리

---
## 🤔 고민한 점 및 해결 과정
- **Issue**: `/signup/info` 페이지가 이메일 회원가입 전용으로만 구현되어 있어 GitHub 회원가입 시 `tempUserId` 없음 에러 발생
- **Decision**: `AdditionalInfoForm.tsx` 에서 두 케이스 모두 처리하도록 수정
- **Reason**: 페이지는 하나지만 회원가입 방식에 따라 다른 API를 호출해야 하기 때문

---
## 💡 리뷰어 전달 사항
- **우려되는 부분**: 백엔드 `/api/auth/signup/github` 500 에러로 GitHub 회원가입 완료 테스트 필요