### PR TITLE
[Feature] 메인 대시보드 UI 구현

### DIFF
--- a/src/app/home/page.tsx
+++ b/src/app/home/page.tsx
@@ -1,0 +1,68 @@
+import FeatureCard from '@/features/home/components/FeatureCard'
+
+const HomePage = () => {
+  return (
+    <div className="flex w-full flex-col gap-16 px-6 py-10">
+      {/* Hero Section */}
+      <section className="flex flex-col items-center justify-center gap-4">
+        <div className="flex w-fit items-center gap-2 rounded-full border border-neutral-200 bg-neutral-50 px-4 py-2">
+          <div className="h-2 w-2 rounded-full bg-emerald-500" />
+
+          <span className="caption-m-sm text-neutral-500">
+            개발 스토리를 포트폴리오로
+          </span>
+        </div>
+
+        <div className="flex flex-col gap-6 text-center">
+          <h1 className="title-bold max-w-[760px] text-neutral-950">
+            나만의 개발 스토리를 담는
+            <br />
+            포트폴리오 서비스
+          </h1>
+
+          <p className="body-m max-w-[560px] break-keep text-neutral-400">
+            GitHub 활동과 프로젝트 경험을 연결해
+            <br />
+            나만의 개발 여정을 한눈에 정리해보세요.
+          </p>
+        </div>
+      </section>
+
+      {/* Cards */}
+      <section>
+        <div className="grid grid-cols-3 gap-6">
+          <FeatureCard
+            label="PROJECT ARCHIVE"
+            title={'프로젝트를\n보기 좋게 정리'}
+            theme="dark"
+          />
+
+          <FeatureCard
+            label="GITHUB SYNC"
+            title={'GitHub 기록을\n자동으로 연결'}
+            theme="light"
+          />
+
+          <FeatureCard
+            label="TECH STACK"
+            title={'기술 스택과\n성장 흐름 시각화'}
+            theme="blue"
+          />
+        </div>
+      </section>
+
+      {/* CTA */}
+      <section className="flex flex-col items-center gap-4">
+        <button className="body-sb rounded-2xl bg-[#1C1C1C] px-10 py-5 text-white transition hover:opacity-90">
+          Github에서 레포지토리 불러오기
+        </button>
+
+        <p className="caption-m-sm text-neutral-400">
+          몇 분 안에 나만의 포트폴리오를 시작해보세요.
+        </p>
+      </section>
+    </div>
+  )
+}
+
+export default HomePage

--- a/src/app/home/page.tsx
+++ b/src/app/home/page.tsx
@@ -1,10 +1,11 @@
 import FeatureCard from '@/features/home/components/FeatureCard'
+import { Button } from '@/components/ui/button'
 
 const HomePage = () => {
   return (
-    <div className="flex w-full flex-col gap-16 px-6 py-10">
+    <div className="flex w-full flex-col gap-20 px-6 py-12">
       {/* Hero Section */}
-      <section className="flex flex-col items-center justify-center gap-4">
+      <section className="flex flex-col items-center justify-center gap-5">
         <div className="flex w-fit items-center gap-2 rounded-full border border-neutral-200 bg-neutral-50 px-4 py-2">
           <div className="h-2 w-2 rounded-full bg-emerald-500" />
 
@@ -13,14 +14,14 @@ const HomePage = () => {
           </span>
         </div>
 
-        <div className="flex flex-col gap-6 text-center">
-          <h1 className="title-bold max-w-[760px] text-neutral-950">
+        <div className="flex flex-col items-center gap-6 text-center">
+          <h1 className="title-bold text-neutral-950">
             나만의 개발 스토리를 담는
             <br />
             포트폴리오 서비스
           </h1>
 
-          <p className="body-m max-w-[560px] break-keep text-neutral-400">
+          <p className="body-m break-keep leading-relaxed text-neutral-400">
             GitHub 활동과 프로젝트 경험을 연결해
             <br />
             나만의 개발 여정을 한눈에 정리해보세요.
@@ -52,10 +53,13 @@ const HomePage = () => {
       </section>
 
       {/* CTA */}
-      <section className="flex flex-col items-center gap-4">
-        <button className="body-sb rounded-2xl bg-[#1C1C1C] px-10 py-5 text-white transition hover:opacity-90">
+      <section className="flex flex-col items-center gap-3">
+        <Button
+          variant="secondary"
+          className="body-sb h-auto rounded-2xl bg-neutral-900 px-10 py-5 text-white hover:bg-neutral-800"
+        >
           Github에서 레포지토리 불러오기
-        </button>
+        </Button>
 
         <p className="caption-m-sm text-neutral-400">
           몇 분 안에 나만의 포트폴리오를 시작해보세요.

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,41 +1,48 @@
-import localFont from "next/font/local";
-import { Archivo_Black } from "next/font/google";
-import Link from "next/link";
-import "./globals.css";
-import Header from "@/components/layout/Header";
+import localFont from 'next/font/local'
+import { Archivo_Black } from 'next/font/google'
+import Link from 'next/link'
+
+import Header from '@/components/layout/Header'
+import Footer from '@/components/layout/Footer'
+
+import './globals.css'
 
 const pretendard = localFont({
-  src: "../assets/fonts/PretendardVariable.ttf",
-  display: "swap",
-  weight: "45 920",
-  variable: "--font-pretendard",
-});
+  src: '../assets/fonts/PretendardVariable.ttf',
+  display: 'swap',
+  weight: '45 920',
+  variable: '--font-pretendard',
+})
 
 const archivoBlack = Archivo_Black({
-  weight: "400",
-  subsets: ["latin"],
-  variable: "--font-archivo-black",
-});
+  weight: '400',
+  subsets: ['latin'],
+  variable: '--font-archivo-black',
+})
 
-export default function RootLayout({
+const RootLayout = ({
   children,
-}: {
-  children: React.ReactNode;
-}) {
+}: Readonly<{
+  children: React.ReactNode
+}>) => {
   return (
-    <html lang="ko" className={`${pretendard.variable} ${archivoBlack.variable}`}>
-      <body className="font-pretendard antialiased">
-        <Header />
-        {children}
-        <footer className="fixed bottom-0 left-0 px-6 py-4">
-          <Link
-            href="/terms"
-            className="caption-m-lg text-[#525252] cursor-pointer hover:underline"
-          >
-            이용 약관
-          </Link>
-        </footer>
+    <html
+      lang="ko"
+      className={`${pretendard.variable} ${archivoBlack.variable}`}
+    >
+      <body className="font-pretendard min-h-screen antialiased">
+        <div className="flex min-h-screen flex-col">
+          <Header />
+
+          <main className="flex-1">
+            {children}
+          </main>
+
+          <Footer />
+        </div>
       </body>
     </html>
-  );
+  )
 }
+
+export default RootLayout

--- a/src/components/layout/Footer.tsx
+++ b/src/components/layout/Footer.tsx
@@ -1,0 +1,44 @@
+import Link from 'next/link'
+
+const Footer = () => {
+  return (
+    <footer className="border-t border-neutral-200 bg-white">
+      <div className="flex w-full items-center justify-between px-6 py-5">
+        <div className="flex flex-col gap-1">
+          <span className="caption-m-sm text-neutral-900">
+            AUTOPORT
+          </span>
+
+          <p className="caption-m-sm text-neutral-400">
+            나만의 개발 스토리를 담는 포트폴리오 서비스
+          </p>
+        </div>
+
+        <div className="flex items-center gap-6">
+          <Link
+            href="/terms"
+            className="caption-m-sm text-neutral-500 transition hover:text-neutral-900"
+          >
+            이용약관
+          </Link>
+
+          <Link
+            href="/privacy"
+            className="caption-m-sm text-neutral-500 transition hover:text-neutral-900"
+          >
+            개인정보처리방침
+          </Link>
+
+          <Link
+            href="/contact"
+            className="caption-m-sm text-neutral-500 transition hover:text-neutral-900"
+          >
+            문의하기
+          </Link>
+        </div>
+      </div>
+    </footer>
+  )
+}
+
+export default Footer

--- a/src/features/auth/components/SignupComplete.tsx
+++ b/src/features/auth/components/SignupComplete.tsx
@@ -12,7 +12,7 @@ export default function SignupComplete() {
         <h1 className="title-bold">회원가입이 완료되었습니다!</h1>
         <Image src="/octopus.svg" alt="" width={400} height={400} />
         <button
-          onClick={() => router.push('/')}
+          onClick={() => router.push('/home')}
           className="bg-blue-500 text-white py-3 px-6 rounded-md body-m"
         >
           포트폴리오 만들러 가기

--- a/src/features/home/components/FeatureCard.tsx
+++ b/src/features/home/components/FeatureCard.tsx
@@ -1,0 +1,33 @@
+interface FeatureCardProps {
+  label: string
+  title: string
+  theme: 'dark' | 'light' | 'blue'
+}
+
+const themeClass = {
+  dark: 'bg-neutral-900 text-white',
+  light: 'bg-neutral-100 text-black',
+  blue: 'bg-[#E8F1FF] text-black',
+}
+
+export default function FeatureCard({
+  label,
+  title,
+  theme,
+}: FeatureCardProps) {
+  return (
+    <article
+      className={`flex flex-col justify-between rounded-[36px] p-8 ${themeClass[theme]}`}
+    >
+      <div>
+        <p className="caption-m-lg opacity-60">
+          {label}
+        </p>
+
+        <h2 className="title-bold mt-6 whitespace-pre-line">
+          {title}
+        </h2>
+      </div>
+    </article>
+  )
+}


### PR DESCRIPTION
## 📌 개요

- **관련 이슈**:  Closes #3 
- **작업 요약**: 로그인 후 보여지는 홈 페이지 메인 대시보드 구현

---

## 🔍 주요 구현 내용

- 로그인 후 진입 가능한 홈 페이지 레이아웃 구현
- Hero Section, Feature Card, CTA 영역 구현
- FeatureCard 컴포넌트 분리 및 재사용 구조 적용
- 공통 Button 컴포넌트를 활용하도록 CTA 버튼 구조 개선
- RootLayout 구조를 flex 기반으로 리팩토링하여 전역 레이아웃 정리
- Footer 컴포넌트 추가 및 전역 레이아웃에 적용

---

## 📸 실행 결과 (이미지/GIF)

<img width="1277" height="692" alt="image" src="https://github.com/user-attachments/assets/f6f063fa-867a-48c9-a7ca-49eeda408f13" />


---
