### PR TITLE
[Feature] Repository 조회 API 연동

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "lint": "eslint"
   },
   "dependencies": {
+    "axios": "^1.16.1",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "lucide-react": "^1.8.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      axios:
+        specifier: ^1.16.1
+        version: 1.16.1
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
@@ -1624,6 +1627,10 @@ packages:
     engines: {node: '>=0.4.0'}
     hasBin: true
 
+  agent-base@6.0.2:
+    resolution: {integrity: sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==}
+    engines: {node: '>= 6.0.0'}
+
   agent-base@7.1.4:
     resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
     engines: {node: '>= 14'}
@@ -1708,6 +1715,9 @@ packages:
     resolution: {integrity: sha512-hsU18Ae8CDTR6Kgu9DYf0EbCr/a5iGL0rytQDobUcdpYOKokk8LEjVphnXkDkgpi0wYVsqrXuP0bZxJaTqdgoA==}
     engines: {node: '>= 0.4'}
 
+  asynckit@0.4.0:
+    resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
+
   available-typed-arrays@1.0.7:
     resolution: {integrity: sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==}
     engines: {node: '>= 0.4'}
@@ -1715,6 +1725,9 @@ packages:
   axe-core@4.11.2:
     resolution: {integrity: sha512-byD6KPdvo72y/wj2T/4zGEvvlis+PsZsn/yPS3pEO+sFpcrqRpX/TJCxvVaEsNeMrfQbCr7w163YqoD9IYwHXw==}
     engines: {node: '>=4'}
+
+  axios@1.16.1:
+    resolution: {integrity: sha512-caYkukvroVPO8KrzuJEb50Hm07KwfBZPEC3VeFHTsqWHvKTsy54hjJz9BS/cdaypROE2rH6xvm9mHX4fgWkr3A==}
 
   axobject-query@4.1.0:
     resolution: {integrity: sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==}
@@ -1822,6 +1835,10 @@ packages:
 
   color-name@1.1.4:
     resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
+
+  combined-stream@1.0.8:
+    resolution: {integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==}
+    engines: {node: '>= 0.8'}
 
   commander@11.1.0:
     resolution: {integrity: sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ==}
@@ -1952,6 +1969,10 @@ packages:
   define-properties@1.2.1:
     resolution: {integrity: sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==}
     engines: {node: '>= 0.4'}
+
+  delayed-stream@1.0.0:
+    resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
+    engines: {node: '>=0.4.0'}
 
   depd@2.0.0:
     resolution: {integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==}
@@ -2281,9 +2302,22 @@ packages:
   flatted@3.4.2:
     resolution: {integrity: sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==}
 
+  follow-redirects@1.16.0:
+    resolution: {integrity: sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==}
+    engines: {node: '>=4.0'}
+    peerDependencies:
+      debug: '*'
+    peerDependenciesMeta:
+      debug:
+        optional: true
+
   for-each@0.3.5:
     resolution: {integrity: sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==}
     engines: {node: '>= 0.4'}
+
+  form-data@4.0.5:
+    resolution: {integrity: sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==}
+    engines: {node: '>= 6'}
 
   formdata-polyfill@4.0.10:
     resolution: {integrity: sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==}
@@ -2435,6 +2469,10 @@ packages:
   http-errors@2.0.1:
     resolution: {integrity: sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==}
     engines: {node: '>= 0.8'}
+
+  https-proxy-agent@5.0.1:
+    resolution: {integrity: sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==}
+    engines: {node: '>= 6'}
 
   https-proxy-agent@7.0.6:
     resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
@@ -2864,8 +2902,16 @@ packages:
     resolution: {integrity: sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==}
     engines: {node: '>=8.6'}
 
+  mime-db@1.52.0:
+    resolution: {integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==}
+    engines: {node: '>= 0.6'}
+
   mime-db@1.54.0:
     resolution: {integrity: sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==}
+    engines: {node: '>= 0.6'}
+
+  mime-types@2.1.35:
+    resolution: {integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==}
     engines: {node: '>= 0.6'}
 
   mime-types@3.0.2:
@@ -3200,6 +3246,10 @@ packages:
   proxy-addr@2.0.7:
     resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
     engines: {node: '>= 0.10'}
+
+  proxy-from-env@2.1.0:
+    resolution: {integrity: sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==}
+    engines: {node: '>=10'}
 
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
@@ -5378,6 +5428,12 @@ snapshots:
 
   acorn@8.16.0: {}
 
+  agent-base@6.0.2:
+    dependencies:
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
   agent-base@7.1.4: {}
 
   ajv-formats@3.0.1(ajv@8.18.0):
@@ -5489,11 +5545,23 @@ snapshots:
 
   async-function@1.0.0: {}
 
+  asynckit@0.4.0: {}
+
   available-typed-arrays@1.0.7:
     dependencies:
       possible-typed-array-names: 1.1.0
 
   axe-core@4.11.2: {}
+
+  axios@1.16.1:
+    dependencies:
+      follow-redirects: 1.16.0
+      form-data: 4.0.5
+      https-proxy-agent: 5.0.1
+      proxy-from-env: 2.1.0
+    transitivePeerDependencies:
+      - debug
+      - supports-color
 
   axobject-query@4.1.0: {}
 
@@ -5602,6 +5670,10 @@ snapshots:
 
   color-name@1.1.4: {}
 
+  combined-stream@1.0.8:
+    dependencies:
+      delayed-stream: 1.0.0
+
   commander@11.1.0: {}
 
   commander@14.0.3: {}
@@ -5700,6 +5772,8 @@ snapshots:
       define-data-property: 1.1.4
       has-property-descriptors: 1.0.2
       object-keys: 1.1.1
+
+  delayed-stream@1.0.0: {}
 
   depd@2.0.0: {}
 
@@ -6214,9 +6288,19 @@ snapshots:
 
   flatted@3.4.2: {}
 
+  follow-redirects@1.16.0: {}
+
   for-each@0.3.5:
     dependencies:
       is-callable: 1.2.7
+
+  form-data@4.0.5:
+    dependencies:
+      asynckit: 0.4.0
+      combined-stream: 1.0.8
+      es-set-tostringtag: 2.1.0
+      hasown: 2.0.2
+      mime-types: 2.1.35
 
   formdata-polyfill@4.0.10:
     dependencies:
@@ -6356,6 +6440,13 @@ snapshots:
       setprototypeof: 1.2.0
       statuses: 2.0.2
       toidentifier: 1.0.1
+
+  https-proxy-agent@5.0.1:
+    dependencies:
+      agent-base: 6.0.2
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
 
   https-proxy-agent@7.0.6:
     dependencies:
@@ -6713,7 +6804,13 @@ snapshots:
       braces: 3.0.3
       picomatch: 2.3.2
 
+  mime-db@1.52.0: {}
+
   mime-db@1.54.0: {}
+
+  mime-types@2.1.35:
+    dependencies:
+      mime-db: 1.52.0
 
   mime-types@3.0.2:
     dependencies:
@@ -7011,6 +7108,8 @@ snapshots:
     dependencies:
       forwarded: 0.2.0
       ipaddr.js: 1.9.1
+
+  proxy-from-env@2.1.0: {}
 
   punycode@2.3.1: {}
 

--- a/src/app/home/page.tsx
+++ b/src/app/home/page.tsx
@@ -1,26 +1,28 @@
+'use client'
+
 import FeatureCard from '@/features/home/components/FeatureCard'
 import { Button } from '@/components/ui/button'
+import { useGithubRepos } from '@/hooks/useGithubRepos'
 
 const HomePage = () => {
+  const { isLoading, error, fetchRepos } = useGithubRepos()
+
   return (
     <div className="flex w-full flex-col gap-20 px-6 py-12">
       {/* Hero Section */}
       <section className="flex flex-col items-center justify-center gap-5">
         <div className="flex w-fit items-center gap-2 rounded-full border border-neutral-200 bg-neutral-50 px-4 py-2">
           <div className="h-2 w-2 rounded-full bg-emerald-500" />
-
           <span className="caption-m-sm text-neutral-500">
             개발 스토리를 포트폴리오로
           </span>
         </div>
-
         <div className="flex flex-col items-center gap-6 text-center">
           <h1 className="title-bold text-neutral-950">
             나만의 개발 스토리를 담는
             <br />
             포트폴리오 서비스
           </h1>
-
           <p className="body-m break-keep leading-relaxed text-neutral-400">
             GitHub 활동과 프로젝트 경험을 연결해
             <br />
@@ -28,7 +30,6 @@ const HomePage = () => {
           </p>
         </div>
       </section>
-
       {/* Cards */}
       <section>
         <div className="grid grid-cols-3 gap-6">
@@ -37,13 +38,11 @@ const HomePage = () => {
             title={'프로젝트를\n보기 좋게 정리'}
             theme="dark"
           />
-
           <FeatureCard
             label="GITHUB SYNC"
             title={'GitHub 기록을\n자동으로 연결'}
             theme="light"
           />
-
           <FeatureCard
             label="TECH STACK"
             title={'기술 스택과\n성장 흐름 시각화'}
@@ -51,18 +50,18 @@ const HomePage = () => {
           />
         </div>
       </section>
-
       {/* CTA */}
       <section className="flex flex-col items-center gap-3">
         <Button
           variant="secondary"
-          className="body-sb h-auto rounded-2xl bg-neutral-900 px-10 py-5 text-white hover:bg-neutral-800"
+          className="body-sb h-auto rounded-2xl bg-neutral-900 px-10 py-5 text-white hover:bg-neutral-800 disabled:opacity-50"
+          onClick={fetchRepos}
+          disabled={isLoading}
         >
-          Github에서 레포지토리 불러오기
+          {isLoading ? '불러오는 중...' : 'Github에서 레포지토리 불러오기'}
         </Button>
-
         <p className="caption-m-sm text-neutral-400">
-          몇 분 안에 나만의 포트폴리오를 시작해보세요.
+          {error ?? '몇 분 안에 나만의 포트폴리오를 시작해보세요.'}
         </p>
       </section>
     </div>

--- a/src/features/auth/components/LoginPage.tsx
+++ b/src/features/auth/components/LoginPage.tsx
@@ -15,7 +15,7 @@ export default function LoginPage() {
     const res = await localLogin({ email, password })
     if (res.success) {
       localStorage.setItem('accessToken', res.data.accessToken)
-      router.push('/')
+      router.push('/home')
     } else {
       alert('이메일 또는 비밀번호가 올바르지 않습니다!')
     }

--- a/src/hooks/useGithubRepos.ts
+++ b/src/hooks/useGithubRepos.ts
@@ -1,0 +1,59 @@
+import { useState } from 'react'
+import axios from 'axios'
+import axiosInstance from '@/lib/api/axios'
+
+interface Repo {
+  repoId: number
+  name: string
+  fullName: string
+  htmlUrl: string
+  description: string | null
+  language: string | null
+  stargazersCount: number
+  forksCount: number
+  updatedAt: string
+  private: boolean
+}
+
+interface RepoResponse {
+  success: boolean
+  data: {
+    content: Repo[]
+    page: number
+    perPage: number
+    totalElements: number
+    totalPages: number
+  }
+}
+
+export const useGithubRepos = () => {
+  const [repos, setRepos] = useState<Repo[]>([])
+  const [isLoading, setIsLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const fetchRepos = async () => {
+    setIsLoading(true)
+    setError(null)
+
+    try {
+      const { data } = await axiosInstance.get<RepoResponse>('/api/github/repos', {
+        params: { sort: 'updated', direction: 'desc', page: 1, perPage: 30 },
+      })
+
+      setRepos(data.data.content)
+    } catch (err) {
+      if (axios.isAxiosError(err)) {
+        const status = err.response?.status
+        if (status === 400) setError('인증이 만료되었습니다. 다시 로그인해주세요.')
+        else if (status === 403) setError('GitHub 연동이 필요합니다.')
+        else setError('레포지토리를 불러오지 못했습니다.')
+      } else {
+        setError('알 수 없는 오류가 발생했습니다.')
+      }
+    } finally {
+      setIsLoading(false)
+    }
+  }
+
+  return { repos, isLoading, error, fetchRepos }
+}

--- a/src/lib/api/axios.ts
+++ b/src/lib/api/axios.ts
@@ -1,0 +1,19 @@
+import axios from 'axios';
+
+const axiosInstance = axios.create({
+  baseURL: process.env.NEXT_PUBLIC_API_URL,
+});
+
+axiosInstance.interceptors.request.use((config) => {
+  if (typeof window !== 'undefined') {
+    const token = localStorage.getItem('accessToken');
+
+    if (token) {
+      config.headers.Authorization = `Bearer ${token}`;
+    }
+  }
+
+  return config;
+});
+
+export default axiosInstance;


### PR DESCRIPTION
## 📌 개요
- **관련 이슈**: Close #4
- **작업 요약**: GitHub 레포지토리 목록 조회 API 연동 및 홈 화면 버튼에 연결

---

## 🔍 주요 구현 내용

- **`useGithubRepos` 훅 추가**: `/api/github/repos` 엔드포인트를 호출해 레포지토리 목록을 가져오는 커스텀 훅 구현
- **axios 인스턴스 기반 API 호출**: 공통 인스턴스를 사용해 baseURL 및 Authorization 헤더를 자동 주입
- **홈 화면 버튼 연결**: '레포지토리 불러오기' 버튼 클릭 시 API 호출, 로딩 중 버튼 비활성화 및 텍스트 변경, 에러 메시지 노출 처리
- `useGithubRepos`: `isLoading`, `error`, `fetchRepos`를 반환하며 axios의 `isAxiosError`로 HTTP 상태코드별 에러 메시지를 분기 처리
- `HomePage`: `'use client'` 선언 후 훅을 연결, 버튼의 `onClick`, `disabled` 상태와 에러 문구를 바인딩

