### PR TITLE
[Feature] repository 선택 화면 구현

### DIFF
--- a/src/app/home/repos/page.tsx
+++ b/src/app/home/repos/page.tsx
@@ -1,0 +1,82 @@
+'use client'
+
+import { useRepoStore } from '@/store/repoStore'
+import { useRouter } from 'next/navigation'
+
+const ReposPage = () => {
+  const { repos, selectedRepo, setSelectedRepo } = useRepoStore()
+  const router = useRouter()
+
+  return (
+    <div className="flex w-full flex-col items-center gap-8 px-6 py-12">
+      {/* 상단 타이틀 */}
+      <div className="flex flex-col items-center gap-1 text-center">
+        <h1 className="title-bold text-neutral-950">
+          포트폴리오를 생성할
+          <br />
+          레포지토리를 선택해 주세요
+        </h1>
+      </div>
+
+      {/* 레포 리스트 박스 */}
+      <div className="relative w-full max-w-xl rounded-2xl border border-neutral-200 p-6">
+        {/* 스크롤 영역 */}
+        <ul className="flex max-h-96 flex-col gap-3 overflow-y-auto">
+          {repos.length === 0 ? (
+            <div className="flex h-64 flex-col items-center justify-center gap-2 text-center">
+              <p className="body-m text-neutral-400">레포지토리 리스트</p>
+              <p className="caption-m-sm text-neutral-300">레포지토리가 존재하지 않아요</p>
+            </div>
+          ) : (
+            repos.map((repo) => {
+              const isSelected = selectedRepo?.repoId === repo.repoId
+              return (
+                <li
+                  key={repo.repoId}
+                  onClick={() => setSelectedRepo(repo)}
+                  className={`flex cursor-pointer flex-col gap-1.5 rounded-xl border p-4 transition-all ${
+                    isSelected
+                      ? 'border-neutral-900 bg-neutral-900 text-white'
+                      : 'border-neutral-200 bg-white hover:border-neutral-400'
+                  }`}
+                >
+                  <div className="flex items-center justify-between">
+                    <span className="body-sb">{repo.fullName}</span>
+                    {repo.private && (
+                      <span className={`caption-m-sm rounded-full border px-2 py-0.5 ${isSelected ? 'border-neutral-600 text-neutral-400' : 'border-neutral-300 text-neutral-400'}`}>
+                        Private
+                      </span>
+                    )}
+                  </div>
+                  {repo.description && (
+                    <p className={`body-m ${isSelected ? 'text-neutral-300' : 'text-neutral-500'}`}>
+                      {repo.description}
+                    </p>
+                  )}
+                  <div className={`caption-m-sm flex gap-3 ${isSelected ? 'text-neutral-400' : 'text-neutral-400'}`}>
+                    {repo.language && <span>{repo.language}</span>}
+                    <span>⭐ {repo.stargazersCount}</span>
+                    <span>🍴 {repo.forksCount}</span>
+                  </div>
+                </li>
+              )
+            })
+          )}
+        </ul>
+
+        {/* 다음 버튼 - 박스 우측 하단 */}
+        <div className="mt-4 flex justify-end">
+          <button
+            onClick={() => router.push('/next-step')} // 다음 경로로 수정
+            disabled={!selectedRepo}
+            className="body-sb rounded-xl bg-neutral-200 px-6 py-2.5 text-neutral-700 transition-all hover:bg-neutral-900 hover:text-white disabled:cursor-not-allowed disabled:opacity-40"
+          >
+            다음
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export default ReposPage

--- a/src/hooks/useGithubRepos.ts
+++ b/src/hooks/useGithubRepos.ts
@@ -1,19 +1,8 @@
 import { useState } from 'react'
+import { useRouter } from 'next/navigation'
 import axios from 'axios'
 import axiosInstance from '@/lib/api/axios'
-
-interface Repo {
-  repoId: number
-  name: string
-  fullName: string
-  htmlUrl: string
-  description: string | null
-  language: string | null
-  stargazersCount: number
-  forksCount: number
-  updatedAt: string
-  private: boolean
-}
+import { useRepoStore, Repo } from '@/store/repoStore'
 
 interface RepoResponse {
   success: boolean
@@ -27,9 +16,10 @@ interface RepoResponse {
 }
 
 export const useGithubRepos = () => {
-  const [repos, setRepos] = useState<Repo[]>([])
   const [isLoading, setIsLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
+  const setRepos = useRepoStore((state) => state.setRepos)
+  const router = useRouter()
 
   const fetchRepos = async () => {
     setIsLoading(true)
@@ -41,6 +31,7 @@ export const useGithubRepos = () => {
       })
 
       setRepos(data.data.content)
+      router.push('/home/repos')
     } catch (err) {
       if (axios.isAxiosError(err)) {
         const status = err.response?.status
@@ -55,5 +46,5 @@ export const useGithubRepos = () => {
     }
   }
 
-  return { repos, isLoading, error, fetchRepos }
+  return { isLoading, error, fetchRepos }
 }

--- a/src/store/repoStore.ts
+++ b/src/store/repoStore.ts
@@ -1,0 +1,28 @@
+import { create } from 'zustand'
+
+export interface Repo {
+  repoId: number
+  name: string
+  fullName: string
+  htmlUrl: string
+  description: string | null
+  language: string | null
+  stargazersCount: number
+  forksCount: number
+  updatedAt: string
+  private: boolean
+}
+
+interface RepoStore {
+  repos: Repo[]
+  selectedRepo: Repo | null
+  setRepos: (repos: Repo[]) => void
+  setSelectedRepo: (repo: Repo) => void
+}
+
+export const useRepoStore = create<RepoStore>((set) => ({
+  repos: [],
+  selectedRepo: null,
+  setRepos: (repos) => set({ repos }),
+  setSelectedRepo: (repo) => set({ selectedRepo: repo }),
+}))


### PR DESCRIPTION
## 📌 개요

- **관련 이슈**: #5 
- **작업 요약**: 포트폴리오 생성을 위한 GitHub 레포지토리 선택 화면 구현

---

## 🔍 주요 구현 내용

- **`useRepoStore` (zustand) 추가**: 불러온 레포 목록과 선택된 레포 상태를 전역 저장소에서 관리
- **`useGithubRepos` 훅 업데이트**: API 성공 시 store에 데이터 저장 후 `/home/repos`로 자동 이동

---

## 📸 실행 결과 (이미지/GIF)

<img width="1277" height="693" alt="image" src="https://github.com/user-attachments/assets/5f12d19a-5ae4-4d75-be55-a09fdb59738e" />


---

