### PR TITLE
[Feature] Repository 분석 결과 화면 구현

### DIFF
--- a/src/app/home/repos/analyze/page.tsx
+++ b/src/app/home/repos/analyze/page.tsx
@@ -1,0 +1,153 @@
+'use client'
+
+import { useRepoStore } from '@/store/repoStore'
+import { useRouter } from 'next/navigation'
+
+const AnalyzePage = () => {
+  const { analyzeResult } = useRepoStore()
+  const router = useRouter()
+
+  if (!analyzeResult) {
+    return (
+      <div className="flex flex-1 flex-col items-center justify-center gap-4">
+        <p className="body-m text-neutral-400">분석 결과가 없습니다.</p>
+        <button
+          onClick={() => router.push('/home/repos')}
+          className="caption-m-sm text-neutral-500 underline underline-offset-4"
+        >
+          레포지토리 선택으로 돌아가기
+        </button>
+      </div>
+    )
+  }
+
+  const { aiInputData } = analyzeResult
+
+  return (
+    <div className="flex w-full flex-col items-center gap-10 px-6 py-12">
+      {/* 헤더 */}
+      <div className="flex w-full max-w-2xl flex-col gap-1">
+        <span className="caption-m-sm text-neutral-400">분석 완료</span>
+        <h1 className="title-bold text-neutral-950">{analyzeResult.repoName}</h1>
+        {analyzeResult.description && (
+          <p className="body-m text-neutral-500">{analyzeResult.description}</p>
+        )}
+      </div>
+
+      <div className="flex w-full max-w-2xl flex-col gap-4">
+        {/* 요약 */}
+        <div className="rounded-2xl border border-neutral-200 bg-neutral-50 p-6">
+          <span className="caption-m-sm text-neutral-400">프로젝트 요약</span>
+          <p className="body-m mt-2 leading-relaxed text-neutral-700">{aiInputData.summary}</p>
+        </div>
+
+        {/* 스탯 */}
+        <div className="grid grid-cols-3 gap-3">
+          <div className="flex flex-col gap-1 rounded-2xl border border-neutral-200 p-5">
+            <span className="caption-m-sm text-neutral-400">커밋 수</span>
+            <span className="title-bold text-neutral-950">{analyzeResult.commitCount.toLocaleString()}</span>
+          </div>
+          <div className="flex flex-col gap-1 rounded-2xl border border-neutral-200 p-5">
+            <span className="caption-m-sm text-neutral-400">스타</span>
+            <span className="title-bold text-neutral-950">{analyzeResult.starCount.toLocaleString()}</span>
+          </div>
+          <div className="flex flex-col gap-1 rounded-2xl border border-neutral-200 p-5">
+            <span className="caption-m-sm text-neutral-400">중요도 점수</span>
+            <span className="title-bold text-neutral-950">{analyzeResult.importanceScore}</span>
+          </div>
+        </div>
+
+        {/* 기술 스택 */}
+        <div className="rounded-2xl border border-neutral-200 p-6">
+          <span className="caption-m-sm text-neutral-400">기술 스택</span>
+          <div className="mt-3 flex flex-wrap gap-2">
+            {analyzeResult.techStacks.map((stack) => (
+              <span
+                key={stack}
+                className="caption-m-sm rounded-full bg-neutral-900 px-3 py-1.5 text-white"
+              >
+                {stack}
+              </span>
+            ))}
+          </div>
+        </div>
+
+        {/* 주요 특징 */}
+        {aiInputData.highlights.length > 0 && (
+          <div className="rounded-2xl border border-neutral-200 p-6">
+            <span className="caption-m-sm text-neutral-400">주요 특징</span>
+            <ul className="mt-3 flex flex-col gap-2">
+              {aiInputData.highlights.map((highlight, i) => (
+                <li key={i} className="body-m flex gap-2 text-neutral-700">
+                  <span className="mt-1.5 h-1.5 w-1.5 shrink-0 rounded-full bg-neutral-400" />
+                  {highlight}
+                </li>
+              ))}
+            </ul>
+          </div>
+        )}
+
+        {/* README 요약 */}
+        {analyzeResult.readmeSummary && (
+          <div className="rounded-2xl border border-neutral-200 p-6">
+            <span className="caption-m-sm text-neutral-400">README 요약</span>
+            <p className="body-m mt-2 leading-relaxed text-neutral-700">{analyzeResult.readmeSummary}</p>
+          </div>
+        )}
+
+        {/* 활동 요약 */}
+        {analyzeResult.activitySummary && (
+          <div className="rounded-2xl border border-neutral-200 p-6">
+            <span className="caption-m-sm text-neutral-400">활동 요약</span>
+            <p className="body-m mt-2 leading-relaxed text-neutral-700">{analyzeResult.activitySummary}</p>
+          </div>
+        )}
+
+        {/* 개발 기간 / 주요 언어 */}
+        <div className="grid grid-cols-2 gap-3">
+          <div className="rounded-2xl border border-neutral-200 p-5">
+            <span className="caption-m-sm text-neutral-400">개발 기간</span>
+            <p className="body-sb mt-1 text-neutral-800">{aiInputData.developmentPeriod}</p>
+          </div>
+          <div className="rounded-2xl border border-neutral-200 p-5">
+            <span className="caption-m-sm text-neutral-400">주요 언어</span>
+            <p className="body-sb mt-1 text-neutral-800">{analyzeResult.mainLanguage}</p>
+          </div>
+        </div>
+
+        {/* 최근 커밋 */}
+        {aiInputData.recentCommitMessages.length > 0 && (
+          <div className="rounded-2xl border border-neutral-200 p-6">
+            <span className="caption-m-sm text-neutral-400">최근 커밋</span>
+            <ul className="mt-3 flex flex-col gap-2">
+              {aiInputData.recentCommitMessages.slice(0, 5).map((msg, i) => (
+                <li key={i} className="caption-m-sm flex gap-3 text-neutral-500">
+                  <span className="shrink-0 text-neutral-300">{String(i + 1).padStart(2, '0')}</span>
+                  <span className="truncate">{msg}</span>
+                </li>
+              ))}
+            </ul>
+          </div>
+        )}
+      </div>
+
+      {/* CTA */}
+      <div className="flex w-full max-w-2xl flex-col items-center gap-3">
+        <button
+          onClick={() => router.push('/next-step')} // 다음 step 경로 확정 시 수정
+          className="body-sb w-full rounded-2xl bg-neutral-900 py-5 text-white transition-all hover:bg-neutral-800"
+        >
+          포트폴리오 생성하기
+        </button>
+        <button
+          onClick={() => router.push('/home/repos')}
+          className="caption-m-sm text-neutral-400 underline underline-offset-4"
+        >
+          다른 레포지토리 선택
+        </button>
+      </div>
+    </div>
+  )
+}
+
+export default AnalyzePage

--- a/src/app/home/repos/page.tsx
+++ b/src/app/home/repos/page.tsx
@@ -1,11 +1,10 @@
 'use client'
-
 import { useRepoStore } from '@/store/repoStore'
-import { useRouter } from 'next/navigation'
+import { useAnalyzeRepo } from '@/hooks/useAnalyzeRepo'
 
 const ReposPage = () => {
   const { repos, selectedRepo, setSelectedRepo } = useRepoStore()
-  const router = useRouter()
+  const { isLoading, error, analyzeRepo } = useAnalyzeRepo()
 
   return (
     <div className="flex w-full flex-col items-center gap-8 px-6 py-12">
@@ -17,7 +16,6 @@ const ReposPage = () => {
           레포지토리를 선택해 주세요
         </h1>
       </div>
-
       {/* 레포 리스트 박스 */}
       <div className="relative w-full max-w-xl rounded-2xl border border-neutral-200 p-6">
         {/* 스크롤 영역 */}
@@ -53,7 +51,7 @@ const ReposPage = () => {
                       {repo.description}
                     </p>
                   )}
-                  <div className={`caption-m-sm flex gap-3 ${isSelected ? 'text-neutral-400' : 'text-neutral-400'}`}>
+                  <div className="caption-m-sm flex gap-3 text-neutral-400">
                     {repo.language && <span>{repo.language}</span>}
                     <span>⭐ {repo.stargazersCount}</span>
                     <span>🍴 {repo.forksCount}</span>
@@ -64,19 +62,22 @@ const ReposPage = () => {
           )}
         </ul>
 
+        {error && (
+          <p className="caption-m-sm mt-3 text-red-500">{error}</p>
+        )}
+
         {/* 다음 버튼 - 박스 우측 하단 */}
         <div className="mt-4 flex justify-end">
           <button
-            onClick={() => router.push('/next-step')} // 다음 경로로 수정
-            disabled={!selectedRepo}
+            onClick={analyzeRepo}
+            disabled={!selectedRepo || isLoading}
             className="body-sb rounded-xl bg-neutral-200 px-6 py-2.5 text-neutral-700 transition-all hover:bg-neutral-900 hover:text-white disabled:cursor-not-allowed disabled:opacity-40"
           >
-            다음
+            {isLoading ? '분석 중...' : '다음'}
           </button>
         </div>
       </div>
     </div>
   )
 }
-
 export default ReposPage

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -34,7 +34,7 @@ const RootLayout = ({
         <div className="flex min-h-screen flex-col">
           <Header />
 
-          <main className="flex-1">
+          <main className="flex flex-1">
             {children}
           </main>
 

--- a/src/hooks/useAnalyzeRepo.ts
+++ b/src/hooks/useAnalyzeRepo.ts
@@ -1,0 +1,44 @@
+import { useState } from 'react'
+import { useRouter } from 'next/navigation'
+import axios from 'axios'
+import axiosInstance from '@/lib/api/axios'
+import { useRepoStore } from '@/store/repoStore'
+
+export const useAnalyzeRepo = () => {
+  const [isLoading, setIsLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const { selectedRepo, setAnalyzeResult } = useRepoStore()
+  const router = useRouter()
+
+  const analyzeRepo = async () => {
+    if (!selectedRepo) return
+    setIsLoading(true)
+    setError(null)
+
+    try {
+      const [owner, repoName] = selectedRepo.fullName.split('/')
+
+      const { data } = await axiosInstance.post('/api/github/analyze', {
+        repoId: selectedRepo.repoId,
+        repoName,
+        owner,
+      })
+
+      setAnalyzeResult(data.data)
+      router.push('/home/repos/analyze')
+    } catch (err) {
+      if (axios.isAxiosError(err)) {
+        const status = err.response?.status
+        if (status === 400) setError('인증이 만료되었습니다. 다시 로그인해주세요.')
+        else if (status === 403) setError('GitHub 연동이 필요합니다.')
+        else setError('레포지토리 분석에 실패했습니다.')
+      } else {
+        setError('알 수 없는 오류가 발생했습니다.')
+      }
+    } finally {
+      setIsLoading(false)
+    }
+  }
+
+  return { isLoading, error, analyzeRepo }
+}

--- a/src/store/repoStore.ts
+++ b/src/store/repoStore.ts
@@ -13,16 +13,56 @@ export interface Repo {
   private: boolean
 }
 
+export interface AnalyzeResult {
+  repoId: number
+  repoName: string
+  description: string
+  mainLanguage: string
+  techStacks: string[]
+  readmeSummary: string
+  activitySummary: string
+  starCount: number
+  commitCount: number
+  importanceScore: number
+  aiInputData: {
+    projectName: string
+    summary: string
+    stacks: string[]
+    highlights: string[]
+    repoUrl: string
+    description: string
+    mainLanguage: string
+    readmeSummary: string
+    activitySummary: string
+    starCount: number
+    forkCount: number
+    openIssuesCount: number
+    commitCount: number
+    importanceScore: number
+    repositoryCreatedAt: string
+    repositoryUpdatedAt: string
+    firstCommitAt: string
+    latestCommitAt: string
+    developmentPeriod: string
+    recentCommitMessages: string[]
+  }
+  analyzedAt: string
+}
+
 interface RepoStore {
   repos: Repo[]
   selectedRepo: Repo | null
+  analyzeResult: AnalyzeResult | null
   setRepos: (repos: Repo[]) => void
   setSelectedRepo: (repo: Repo) => void
+  setAnalyzeResult: (result: AnalyzeResult) => void
 }
 
 export const useRepoStore = create<RepoStore>((set) => ({
   repos: [],
   selectedRepo: null,
+  analyzeResult: null,
   setRepos: (repos) => set({ repos }),
   setSelectedRepo: (repo) => set({ selectedRepo: repo }),
+  setAnalyzeResult: (result) => set({ analyzeResult: result }),
 }))


### PR DESCRIPTION
## 📌 개요

- **관련 이슈**: #24 
- **작업 요약**: 레포지토리 분석 API 연동 및 분석 결과 화면 구현

---

## 🔍 주요 구현 내용

- **`useAnalyzeRepo` 훅 추가**: 선택된 레포 정보로 `POST /api/github/analyze` 호출, 성공 시 store에 저장 후 `/home/repos/analyze`로 이동
- **`/home/repos/analyze` 페이지 추가**: 분석 결과를 요약, 스탯, 기술 스택, 주요 특징, README 요약, 활동 요약, 개발 기간, 최근 커밋 순으로 렌더링
- **`useRepoStore` 업데이트**: `analyzeResult` 상태 및 `setAnalyzeResult` 액션 추가
- **레포 선택 페이지 업데이트**: 다음 버튼에 `useAnalyzeRepo` 연결, 분석 중 로딩 상태 및 에러 메시지 표시 