### PR TITLE
[Feature] 포트폴리오 최종 생성 구현

### DIFF
--- a/src/app/home/repos/analyze/emphasis/page.tsx
+++ b/src/app/home/repos/analyze/emphasis/page.tsx
@@ -1,0 +1,62 @@
+'use client'
+
+import { useState } from 'react'
+import { useRouter } from 'next/navigation'
+import { useUserMe } from '@/hooks/useUserMe'
+import { useGeneratePortfolio } from '@/hooks/useGeneratePortfolio'
+
+const EmphasisPage = () => {
+  const [emphasis, setEmphasis] = useState('')
+  const { user } = useUserMe()
+  const { isLoading, error, generate } = useGeneratePortfolio()
+  const router = useRouter()
+
+  const handleNext = async () => {
+    if (!user) return
+    await generate(emphasis, user.name)
+  }
+
+  return (
+    <div className="flex w-full flex-col items-center gap-8 px-6 py-12">
+      <div className="flex flex-col items-center gap-1 text-center">
+        <h1 className="title-bold text-neutral-950">
+          프로젝트에서
+          <br />
+          강조하고 싶은 부분을 입력해 주세요
+        </h1>
+      </div>
+
+      <div className="w-full max-w-xl rounded-2xl border border-neutral-200 p-6">
+        <textarea
+          value={emphasis}
+          onChange={(e) => setEmphasis(e.target.value)}
+          placeholder="예) 성능 최적화를 위해 캐싱 전략을 도입했고, API 응답 속도를 50% 개선했습니다."
+          className="body-m h-52 w-full resize-none bg-transparent text-neutral-800 placeholder:text-neutral-300 focus:outline-none"
+        />
+
+        {error && (
+          <p className="caption-m-sm mt-2 text-red-500">{error}</p>
+        )}
+
+        <div className="mt-4 flex justify-end">
+          <button
+            onClick={handleNext}
+            disabled={isLoading || !user}
+            className="body-sb rounded-xl bg-neutral-200 px-6 py-2.5 text-neutral-700 transition-all hover:bg-neutral-900 hover:text-white disabled:cursor-not-allowed disabled:opacity-40"
+          >
+            {isLoading ? '생성 중...' : '다음'}
+          </button>
+        </div>
+      </div>
+
+      <button
+        onClick={() => router.back()}
+        className="caption-m-sm text-neutral-400 underline underline-offset-4"
+      >
+        이전으로
+      </button>
+    </div>
+  )
+}
+
+export default EmphasisPage

--- a/src/app/home/repos/analyze/page.tsx
+++ b/src/app/home/repos/analyze/page.tsx
@@ -140,7 +140,7 @@ const AnalyzePage = () => {
           포트폴리오 생성하기
         </button>
         <button
-          onClick={() => router.push('/home/repos')}
+          onClick={() => router.push('/home/repos/analyze/emphasis')}
           className="caption-m-sm text-neutral-400 underline underline-offset-4"
         >
           다른 레포지토리 선택

--- a/src/app/home/repos/analyze/portfolio/page.tsx
+++ b/src/app/home/repos/analyze/portfolio/page.tsx
@@ -1,0 +1,165 @@
+'use client'
+
+import { useRepoStore } from '@/store/repoStore'
+import { useRouter } from 'next/navigation'
+
+const PortfolioPage = () => {
+  const { portfolioResult } = useRepoStore()
+  const router = useRouter()
+
+  if (!portfolioResult) {
+    return (
+      <div className="flex flex-1 flex-col items-center justify-center gap-4">
+        <p className="body-m text-neutral-400">포트폴리오 결과가 없습니다.</p>
+        <button
+          onClick={() => router.push('/home')}
+          className="caption-m-sm text-neutral-500 underline underline-offset-4"
+        >
+          처음으로 돌아가기
+        </button>
+      </div>
+    )
+  }
+
+  return (
+    <div className="flex w-full flex-col items-center gap-10 px-6 py-12">
+      {/* 헤더 */}
+      <div className="flex w-full max-w-2xl flex-col gap-1">
+        <span className="caption-m-sm text-neutral-400">포트폴리오 생성 완료</span>
+        <h1 className="title-bold text-neutral-950">{portfolioResult.portfolioTitle}</h1>
+        <p className="body-m text-neutral-500">{portfolioResult.introduction}</p>
+      </div>
+
+      <div className="flex w-full max-w-2xl flex-col gap-4">
+        {/* 프로젝트 */}
+        {portfolioResult.projects.map((project, i) => (
+          <div key={i} className="flex flex-col gap-4 rounded-2xl border border-neutral-200 p-6">
+            <div className="flex flex-col gap-1">
+              <span className="caption-m-sm text-neutral-400">프로젝트</span>
+              <h2 className="body-sb text-neutral-950">{project.name}</h2>
+              <p className="body-m text-neutral-500">{project.oneLineDescription}</p>
+            </div>
+
+            <p className="body-m leading-relaxed text-neutral-700">{project.description}</p>
+
+            <div className="grid grid-cols-2 gap-3">
+              <div className="rounded-xl bg-neutral-50 p-4">
+                <span className="caption-m-sm text-neutral-400">개발 기간</span>
+                <p className="body-m mt-1 text-neutral-700">{project.estimatedPeriod}</p>
+              </div>
+              <div className="rounded-xl bg-neutral-50 p-4">
+                <span className="caption-m-sm text-neutral-400">역할</span>
+                <p className="body-m mt-1 text-neutral-700">{project.role}</p>
+              </div>
+            </div>
+
+            {/* 기술 스택 */}
+            <div>
+              <span className="caption-m-sm text-neutral-400">기술 스택</span>
+              <div className="mt-2 flex flex-wrap gap-2">
+                {project.techStacks.map((stack) => (
+                  <span key={stack} className="caption-m-sm rounded-full bg-neutral-900 px-3 py-1.5 text-white">
+                    {stack}
+                  </span>
+                ))}
+              </div>
+            </div>
+
+            {/* 주요 기능 */}
+            {project.mainFeatures.length > 0 && (
+              <div>
+                <span className="caption-m-sm text-neutral-400">주요 기능</span>
+                <ul className="mt-2 flex flex-col gap-1.5">
+                  {project.mainFeatures.map((feature, j) => (
+                    <li key={j} className="body-m flex gap-2 text-neutral-700">
+                      <span className="mt-1.5 h-1.5 w-1.5 shrink-0 rounded-full bg-neutral-400" />
+                      {feature}
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            )}
+
+            {/* 하이라이트 */}
+            {project.highlights.length > 0 && (
+              <div>
+                <span className="caption-m-sm text-neutral-400">하이라이트</span>
+                <ul className="mt-2 flex flex-col gap-1.5">
+                  {project.highlights.map((highlight, j) => (
+                    <li key={j} className="body-m flex gap-2 text-neutral-700">
+                      <span className="mt-1.5 h-1.5 w-1.5 shrink-0 rounded-full bg-emerald-400" />
+                      {highlight}
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            )}
+          </div>
+        ))}
+
+        {/* 기술 기여 */}
+        {portfolioResult.technicalContributions.length > 0 && (
+          <div className="rounded-2xl border border-neutral-200 p-6">
+            <span className="caption-m-sm text-neutral-400">기술적 기여</span>
+            <ul className="mt-3 flex flex-col gap-2">
+              {portfolioResult.technicalContributions.map((item, i) => (
+                <li key={i} className="body-m flex gap-2 text-neutral-700">
+                  <span className="mt-1.5 h-1.5 w-1.5 shrink-0 rounded-full bg-neutral-400" />
+                  {item}
+                </li>
+              ))}
+            </ul>
+          </div>
+        )}
+
+        {/* 코드 하이라이트 */}
+        {portfolioResult.codeHighlights.length > 0 && (
+          <div className="rounded-2xl border border-neutral-200 p-6">
+            <span className="caption-m-sm text-neutral-400">코드 하이라이트</span>
+            <ul className="mt-3 flex flex-col gap-2">
+              {portfolioResult.codeHighlights.map((item, i) => (
+                <li key={i} className="caption-m-sm flex gap-3 text-neutral-500">
+                  <span className="shrink-0 text-neutral-300">{String(i + 1).padStart(2, '0')}</span>
+                  {item}
+                </li>
+              ))}
+            </ul>
+          </div>
+        )}
+
+        {/* 프로젝트 링크 */}
+        {portfolioResult.projectLinks.length > 0 && (
+          <div className="rounded-2xl border border-neutral-200 p-6">
+            <span className="caption-m-sm text-neutral-400">프로젝트 링크</span>
+            <ul className="mt-3 flex flex-col gap-2">
+              {portfolioResult.projectLinks.map((link, i) => (
+                <li key={i}>
+                  <a
+                    href={link}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="body-m text-neutral-700 underline underline-offset-4 hover:text-neutral-950"
+                  >
+                    {link}
+                  </a>
+                </li>
+              ))}
+            </ul>
+          </div>
+        )}
+      </div>
+
+      {/* CTA */}
+      <div className="flex w-full max-w-2xl flex-col items-center gap-3">
+        <button
+          onClick={() => router.push('/home')}
+          className="body-sb w-full rounded-2xl bg-neutral-900 py-5 text-white transition-all hover:bg-neutral-800"
+        >
+          내 포트폴리오 보러가기
+        </button>
+      </div>
+    </div>
+  )
+}
+
+export default PortfolioPage

--- a/src/hooks/useGeneratePortfolio.ts
+++ b/src/hooks/useGeneratePortfolio.ts
@@ -1,0 +1,60 @@
+import { useState } from 'react'
+import { useRouter } from 'next/navigation'
+import axios from 'axios'
+import axiosInstance from '@/lib/api/axios'
+import { useRepoStore } from '@/store/repoStore'
+
+export interface PortfolioResult {
+  portfolioTitle: string
+  introduction: string
+  projects: {
+    name: string
+    oneLineDescription: string
+    description: string
+    estimatedPeriod: string
+    role: string
+    techStacks: string[]
+    mainFeatures: string[]
+    highlights: string[]
+  }[]
+  technicalContributions: string[]
+  codeHighlights: string[]
+  projectLinks: string[]
+  generatedAt: string
+}
+
+export const useGeneratePortfolio = () => {
+  const [isLoading, setIsLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const { analyzeResult, setPortfolioResult } = useRepoStore()
+  const router = useRouter()
+
+  const generate = async (emphasis: string, userName: string) => {
+    if (!analyzeResult) return
+    setIsLoading(true)
+    setError(null)
+
+    try {
+      const { data } = await axiosInstance.post('/api/portfolio/generate', {
+        analysisResult: analyzeResult.aiInputData,
+        userName,
+        emphasis,
+      })
+
+      setPortfolioResult(data.data)
+      router.push('/home/repos/analyze/portfolio')
+    } catch (err) {
+      if (axios.isAxiosError(err)) {
+        const status = err.response?.status
+        if (status === 400) setError('인증이 만료되었습니다. 다시 로그인해주세요.')
+        else setError('포트폴리오 생성에 실패했습니다.')
+      } else {
+        setError('알 수 없는 오류가 발생했습니다.')
+      }
+    } finally {
+      setIsLoading(false)
+    }
+  }
+
+  return { isLoading, error, generate }
+}

--- a/src/hooks/useUserMe.ts
+++ b/src/hooks/useUserMe.ts
@@ -1,0 +1,24 @@
+import { useEffect, useState } from 'react'
+import axiosInstance from '@/lib/api/axios'
+
+interface UserMe {
+  userId: number
+  email: string
+  name: string
+  bio: string
+  provider: string
+  profileImage: string
+  createdAt: string
+}
+
+export const useUserMe = () => {
+  const [user, setUser] = useState<UserMe | null>(null)
+
+  useEffect(() => {
+    axiosInstance.get('/api/users/me')
+      .then(({ data }) => setUser(data.data))
+      .catch(() => setUser(null))
+  }, [])
+
+  return { user }
+}

--- a/src/store/repoStore.ts
+++ b/src/store/repoStore.ts
@@ -1,5 +1,5 @@
 import { create } from 'zustand'
-
+import { PortfolioResult } from '@/hooks/useGeneratePortfolio'
 export interface Repo {
   repoId: number
   name: string
@@ -53,16 +53,20 @@ interface RepoStore {
   repos: Repo[]
   selectedRepo: Repo | null
   analyzeResult: AnalyzeResult | null
+  portfolioResult: PortfolioResult | null
   setRepos: (repos: Repo[]) => void
   setSelectedRepo: (repo: Repo) => void
   setAnalyzeResult: (result: AnalyzeResult) => void
+  setPortfolioResult: (result: PortfolioResult) => void
 }
 
 export const useRepoStore = create<RepoStore>((set) => ({
   repos: [],
   selectedRepo: null,
   analyzeResult: null,
+  portfolioResult: null,
   setRepos: (repos) => set({ repos }),
   setSelectedRepo: (repo) => set({ selectedRepo: repo }),
   setAnalyzeResult: (result) => set({ analyzeResult: result }),
+  setPortfolioResult: (result) => set({ portfolioResult: result }),
 }))


### PR DESCRIPTION
## 📌 개요
- **작업 요약**: 사용자 강조 내용 입력 → 포트폴리오 생성 API 연동 → 결과 화면까지 전체 흐름 구현

---

## 🔍 주요 구현 내용

- **`useUserMe` 훅 추가**: `/api/users/me` 호출해 로그인한 사용자 정보 조회, `userName`을 포트폴리오 생성 요청에 활용
- **`useGeneratePortfolio` 훅 추가**: `emphasis`와 `userName`을 받아 `/api/portfolio/generate` 호출, 성공 시 store에 저장 후 결과 페이지로 이동
- **`/home/repos/analyze/emphasis` 페이지 추가**: 프로젝트에서 강조하고 싶은 내용을 자유롭게 입력하는 textarea UI 구현
- **`/home/repos/analyze/portfolio` 페이지 추가**: 생성된 포트폴리오를 프로젝트, 기술적 기여, 코드 하이라이트, 프로젝트 링크 순으로 렌더링
- **`repoStore` 업데이트**: `portfolioResult` 상태 및 `setPortfolioResult` 액션 추가