### PR TITLE
[Feat] 마이페이지 구현

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,6 +1,7 @@
 import { defineConfig, globalIgnores } from "eslint/config";
 import nextVitals from "eslint-config-next/core-web-vitals";
 import nextTs from "eslint-config-next/typescript";
+import eslintConfigPrettier from "eslint-config-prettier";
 
 const eslintConfig = defineConfig([
   ...nextVitals,

--- a/src/app/home/my/page.tsx
+++ b/src/app/home/my/page.tsx
@@ -1,0 +1,221 @@
+'use client'
+
+import { ArrowRight, FileText, FolderGit, Lock, Plus, UserRound } from 'lucide-react'
+import Link from 'next/link'
+import { useMemo } from 'react'
+import { Button } from '@/components/ui/button'
+import { usePortfolios } from '@/hooks/usePortfolios'
+import { useUserMe } from '@/hooks/useUserMe'
+import { formatKoreanDate } from '@/lib/date'
+
+const MyPage = () => {
+  const { user } = useUserMe()
+  const {
+    portfolios,
+    page,
+    totalPages,
+    totalElements,
+    isLoading,
+    error,
+    setPage,
+  } = usePortfolios()
+
+  const latestUpdatedAt = useMemo(() => {
+    const dates = portfolios
+      .map((portfolio) => new Date(portfolio.updatedAt).getTime())
+      .filter((time) => !Number.isNaN(time))
+
+    if (dates.length === 0) return null
+
+    return new Date(Math.max(...dates)).toISOString()
+  }, [portfolios])
+
+  return (
+    <div className="flex w-full flex-col items-center self-start px-6 py-10">
+      <div className="flex w-full max-w-5xl flex-col gap-8">
+        <section className="grid gap-4 md:grid-cols-[1.2fr_0.8fr]">
+          <div className="flex min-h-48 flex-col justify-between rounded-lg border border-neutral-200 bg-white p-6">
+            <div className="flex items-start gap-4">
+              {user?.profileImage ? (
+                // eslint-disable-next-line @next/next/no-img-element
+                <img
+                  src={user.profileImage}
+                  alt=""
+                  className="h-16 w-16 rounded-full object-cover"
+                />
+              ) : (
+                <div className="flex h-16 w-16 items-center justify-center rounded-full bg-neutral-100 text-neutral-500">
+                  <UserRound size={28} />
+                </div>
+              )}
+              <div className="flex min-w-0 flex-col gap-2">
+                <span className="caption-m-sm text-neutral-400">마이페이지</span>
+                <h1 className="title-sb-lg truncate text-neutral-950">
+                  {user?.name ?? '사용자'}님의 포트폴리오
+                </h1>
+                <p className="body-m break-keep text-neutral-500">
+                  {user?.bio || '생성한 포트폴리오를 모아보고 상세 내용을 확인해요.'}
+                </p>
+              </div>
+            </div>
+
+            <div className="mt-8 grid gap-3 sm:grid-cols-2">
+              <div className="rounded-lg bg-neutral-50 p-4">
+                <span className="caption-m-sm text-neutral-400">이메일</span>
+                <p className="caption-m-lg mt-1 truncate text-neutral-700">
+                  {user?.email ?? '-'}
+                </p>
+              </div>
+              <div className="rounded-lg bg-neutral-50 p-4">
+                <span className="caption-m-sm text-neutral-400">로그인 방식</span>
+                <p className="caption-m-lg mt-1 text-neutral-700">
+                  {user?.provider ?? '-'}
+                </p>
+              </div>
+            </div>
+          </div>
+
+          <div className="grid gap-4 sm:grid-cols-2 md:grid-cols-1">
+            <div className="flex flex-col justify-between rounded-lg border border-blue-100 bg-blue-50 p-5">
+              <span className="caption-m-sm text-blue-500">전체 포트폴리오</span>
+              <strong className="mt-6 text-4xl font-bold leading-none text-neutral-950">
+                {totalElements}
+              </strong>
+            </div>
+            <div className="flex flex-col justify-between rounded-lg border border-neutral-200 bg-white p-5">
+              <span className="caption-m-sm text-neutral-400">최근 업데이트</span>
+              <strong className="body-sb mt-6 text-neutral-950">
+                {formatKoreanDate(latestUpdatedAt ?? undefined)}
+              </strong>
+            </div>
+          </div>
+        </section>
+
+        <section className="flex flex-col gap-4">
+          <div className="flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between">
+            <div>
+              <span className="caption-m-sm text-neutral-400">Portfolio Archive</span>
+              <h2 className="title-sb-md mt-1 text-neutral-950">내 포트폴리오</h2>
+            </div>
+            <Button asChild className="h-10 gap-2 rounded-lg bg-blue-500 px-4 text-white hover:bg-blue-600">
+              <Link href="/home">
+                <Plus size={16} />
+                새 포트폴리오 만들기
+              </Link>
+            </Button>
+          </div>
+
+          {error ? (
+            <div className="flex flex-col gap-3 rounded-lg border border-red-100 bg-red-50 px-5 py-4 text-red-600 sm:flex-row sm:items-center sm:justify-between">
+              <div className="flex flex-col gap-1">
+                <p className="caption-m-lg">{error}</p>
+                <p className="caption-m-sm text-red-400">
+                  로그인 후 생성한 포트폴리오 목록을 확인할 수 있어요.
+                </p>
+              </div>
+              <Button asChild variant="outline" className="h-9 w-fit rounded-lg border-red-200 bg-white px-4 text-red-600 hover:bg-red-100">
+                <Link href="/login">로그인하러 가기</Link>
+              </Button>
+            </div>
+          ) : isLoading ? (
+            <div className="grid gap-3 md:grid-cols-2">
+              {Array.from({ length: 4 }).map((_, index) => (
+                <div key={index} className="h-40 animate-pulse rounded-lg bg-neutral-100" />
+              ))}
+            </div>
+          ) : portfolios.length === 0 ? (
+            <div className="flex min-h-72 flex-col items-center justify-center gap-4 rounded-lg border border-dashed border-neutral-300 bg-neutral-50 px-6 text-center">
+              <div className="flex h-14 w-14 items-center justify-center rounded-full bg-white text-neutral-500">
+                <FileText size={26} />
+              </div>
+              <div className="flex flex-col gap-1">
+                <h3 className="body-sb text-neutral-950">아직 포트폴리오가 없어요</h3>
+                <p className="body-m break-keep text-neutral-500">
+                  레포지토리를 분석해서 첫 포트폴리오를 만들어보세요.
+                </p>
+              </div>
+              <Button asChild className="h-10 rounded-lg bg-blue-500 px-4 text-white hover:bg-blue-600">
+                <Link href="/home">시작하기</Link>
+              </Button>
+            </div>
+          ) : (
+            <div className="grid gap-3 md:grid-cols-2">
+              {portfolios.map((portfolio) => (
+                <Link
+                  key={String(portfolio.portfolioId)}
+                  href={`/home/my/portfolios/${portfolio.portfolioId}`}
+                  className="group flex min-h-44 flex-col justify-between rounded-lg border border-neutral-200 bg-white p-5 transition-all hover:border-neutral-400 hover:bg-neutral-50"
+                >
+                  <div className="flex flex-col gap-3">
+                    <div className="flex items-center justify-between gap-3">
+                      <span className="caption-m-sm text-neutral-400">
+                        Template {portfolio.templateId}
+                      </span>
+                      <span className="inline-flex items-center gap-1 rounded-full border border-neutral-200 px-2 py-1 text-xs font-medium text-neutral-500">
+                        {portfolio.isPublic ? (
+                          <>
+                            <FolderGit size={12} />
+                            Public
+                          </>
+                        ) : (
+                          <>
+                            <Lock size={12} />
+                            Private
+                          </>
+                        )}
+                      </span>
+                    </div>
+                    <div>
+                      <h3 className="body-sb line-clamp-2 text-neutral-950">
+                        {portfolio.title}
+                      </h3>
+                      <p className="body-m mt-2 line-clamp-1 text-neutral-500">
+                        대표 프로젝트: {portfolio.featuredProjectName || '-'}
+                      </p>
+                    </div>
+                  </div>
+
+                  <div className="mt-5 flex items-center justify-between gap-3">
+                    <span className="caption-m-sm text-neutral-400">
+                      {formatKoreanDate(portfolio.updatedAt)}
+                    </span>
+                    <span className="inline-flex items-center gap-1 text-sm font-semibold text-neutral-700 transition-transform group-hover:translate-x-1">
+                      상세보기
+                      <ArrowRight size={15} />
+                    </span>
+                  </div>
+                </Link>
+              ))}
+            </div>
+          )}
+
+          {totalPages > 1 && (
+            <div className="flex items-center justify-center gap-3 pt-2">
+              <Button
+                variant="outline"
+                className="h-9 rounded-lg px-4"
+                disabled={page <= 1}
+                onClick={() => setPage(page - 1)}
+              >
+                이전
+              </Button>
+              <span className="caption-m-sm text-neutral-500">
+                {page} / {totalPages}
+              </span>
+              <Button
+                variant="outline"
+                className="h-9 rounded-lg px-4"
+                disabled={page >= totalPages}
+                onClick={() => setPage(page + 1)}
+              >
+                다음
+              </Button>
+            </div>
+          )}
+        </section>
+      </div>
+    </div>
+  )
+}
+
+export default MyPage

--- a/src/app/home/my/portfolios/[portfolioId]/page.tsx
+++ b/src/app/home/my/portfolios/[portfolioId]/page.tsx
@@ -1,0 +1,187 @@
+'use client'
+
+import { ArrowLeft, ExternalLink, FolderGit, Lock, Star } from 'lucide-react'
+import Link from 'next/link'
+import { useParams } from 'next/navigation'
+import { Button } from '@/components/ui/button'
+import { usePortfolioDetail } from '@/hooks/usePortfolioDetail'
+import { formatKoreanDate } from '@/lib/date'
+
+const PortfolioDetailPage = () => {
+  const params = useParams<{ portfolioId: string }>()
+  const portfolioId = params.portfolioId
+  const { portfolio, isLoading, error } = usePortfolioDetail(portfolioId)
+
+  if (isLoading) {
+    return (
+      <div className="flex w-full justify-center self-start px-6 py-10">
+      <div className="flex w-full max-w-4xl flex-col gap-4 self-start">
+          <div className="h-8 w-36 animate-pulse rounded bg-neutral-100" />
+          <div className="h-44 animate-pulse rounded-lg bg-neutral-100" />
+          <div className="h-72 animate-pulse rounded-lg bg-neutral-100" />
+        </div>
+      </div>
+    )
+  }
+
+  if (error || !portfolio) {
+    return (
+      <div className="flex w-full flex-col items-center justify-center gap-4 self-start px-6 py-20 text-center">
+        <p className="body-m text-neutral-500">
+          {error ?? '포트폴리오를 불러올 수 없어요.'}
+        </p>
+        <Button asChild variant="outline" className="h-10 rounded-lg px-4">
+          <Link href="/home/my">목록으로 돌아가기</Link>
+        </Button>
+      </div>
+    )
+  }
+
+  const featuredProject = portfolio.projects.find(
+    (project) => String(project.repoId) === String(portfolio.featuredProjectId),
+  )
+
+  return (
+    <div className="flex w-full justify-center self-start px-6 py-10">
+      <div className="flex w-full max-w-4xl flex-col gap-6 self-start">
+        <Button asChild variant="ghost" className="h-9 w-fit gap-2 rounded-lg px-2">
+          <Link href="/home/my">
+            <ArrowLeft size={16} />
+            목록으로
+          </Link>
+        </Button>
+
+        <section className="rounded-lg border border-neutral-200 bg-white p-6">
+          <div className="flex flex-col gap-6">
+            <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+              <div className="min-w-0">
+                <span className="caption-m-sm text-neutral-400">
+                  Template {portfolio.templateId}
+                </span>
+                <h1 className="title-bold mt-2 break-keep text-neutral-950">
+                  {portfolio.title}
+                </h1>
+                <p className="body-m mt-3 break-keep leading-relaxed text-neutral-500">
+                  {portfolio.bio || '소개 문구가 아직 없어요.'}
+                </p>
+              </div>
+              <span className="inline-flex w-fit items-center gap-1 rounded-full border border-neutral-200 px-3 py-1.5 text-sm font-medium text-neutral-500">
+                {portfolio.isPublic ? (
+                  <>
+                    <FolderGit size={14} />
+                    Public
+                  </>
+                ) : (
+                  <>
+                    <Lock size={14} />
+                    Private
+                  </>
+                )}
+              </span>
+            </div>
+
+            <div className="grid gap-3 sm:grid-cols-3">
+              <div className="rounded-lg bg-neutral-50 p-4">
+                <span className="caption-m-sm text-neutral-400">생성일</span>
+                <p className="caption-m-lg mt-1 text-neutral-700">
+                  {formatKoreanDate(portfolio.createdAt)}
+                </p>
+              </div>
+              <div className="rounded-lg bg-neutral-50 p-4">
+                <span className="caption-m-sm text-neutral-400">수정일</span>
+                <p className="caption-m-lg mt-1 text-neutral-700">
+                  {formatKoreanDate(portfolio.updatedAt)}
+                </p>
+              </div>
+              <div className="rounded-lg bg-neutral-50 p-4">
+                <span className="caption-m-sm text-neutral-400">프로젝트</span>
+                <p className="caption-m-lg mt-1 text-neutral-700">
+                  {portfolio.projects.length}개
+                </p>
+              </div>
+            </div>
+          </div>
+        </section>
+
+        {featuredProject && (
+          <section className="rounded-lg border border-blue-100 bg-blue-50 p-6">
+            <div className="flex items-center gap-2 text-blue-500">
+              <Star size={16} />
+              <span className="caption-m-sm">대표 프로젝트</span>
+            </div>
+            <h2 className="body-sb mt-4 text-neutral-950">{featuredProject.name}</h2>
+            <p className="body-m mt-2 break-keep text-neutral-600">
+              {featuredProject.description}
+            </p>
+          </section>
+        )}
+
+        <section className="flex flex-col gap-3">
+          <div>
+            <span className="caption-m-sm text-neutral-400">Projects</span>
+            <h2 className="title-sb-md mt-1 text-neutral-950">프로젝트 구성</h2>
+          </div>
+
+          <div className="flex flex-col gap-3">
+            {portfolio.projects.map((project) => (
+              <article
+                key={`${project.repoId}-${project.order}`}
+                className="rounded-lg border border-neutral-200 bg-white p-5"
+              >
+                <div className="flex flex-col gap-4">
+                  <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+                    <div>
+                      <span className="caption-m-sm text-neutral-400">
+                        Project {project.order}
+                      </span>
+                      <h3 className="body-sb mt-1 text-neutral-950">{project.name}</h3>
+                    </div>
+                    {project.githubUrl && (
+                      <Button asChild variant="outline" className="h-9 w-fit gap-2 rounded-lg px-3">
+                        <a href={project.githubUrl} target="_blank" rel="noopener noreferrer">
+                          <FolderGit size={15} />
+                          GitHub
+                          <ExternalLink size={14} />
+                        </a>
+                      </Button>
+                    )}
+                  </div>
+
+                  <p className="body-m break-keep leading-relaxed text-neutral-600">
+                    {project.description}
+                  </p>
+
+                  {project.techStacks.length > 0 && (
+                    <div className="flex flex-wrap gap-2">
+                      {project.techStacks.map((stack) => (
+                        <span
+                          key={stack}
+                          className="rounded-full bg-neutral-100 px-3 py-1.5 text-sm font-medium text-neutral-700"
+                        >
+                          {stack}
+                        </span>
+                      ))}
+                    </div>
+                  )}
+
+                  {project.highlights.length > 0 && (
+                    <ul className="flex flex-col gap-2 border-t border-neutral-100 pt-4">
+                      {project.highlights.map((highlight) => (
+                        <li key={highlight} className="body-m flex gap-2 text-neutral-700">
+                          <span className="mt-2 h-1.5 w-1.5 shrink-0 rounded-full bg-neutral-400" />
+                          <span>{highlight}</span>
+                        </li>
+                      ))}
+                    </ul>
+                  )}
+                </div>
+              </article>
+            ))}
+          </div>
+        </section>
+      </div>
+    </div>
+  )
+}
+
+export default PortfolioDetailPage

--- a/src/hooks/usePortfolioDetail.ts
+++ b/src/hooks/usePortfolioDetail.ts
@@ -1,0 +1,70 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import axios from 'axios'
+import axiosInstance from '@/lib/api/axios'
+
+export interface PortfolioProject {
+  repoId: number | string
+  name: string
+  description: string
+  techStacks: string[]
+  highlights: string[]
+  githubUrl: string
+  order: number
+}
+
+export interface PortfolioDetail {
+  portfolioId: number | string
+  title: string
+  bio: string
+  templateId: number | string
+  featuredProjectId: number | string
+  projects: PortfolioProject[]
+  createdAt: string
+  updatedAt: string
+  isPublic: boolean
+}
+
+interface PortfolioDetailResponse {
+  success: boolean
+  data: PortfolioDetail
+}
+
+export const usePortfolioDetail = (portfolioId: string) => {
+  const [portfolio, setPortfolio] = useState<PortfolioDetail | null>(null)
+  const [isLoading, setIsLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    if (!portfolioId) return
+
+    const fetchPortfolio = async () => {
+      setIsLoading(true)
+      setError(null)
+
+      try {
+        const { data } = await axiosInstance.get<PortfolioDetailResponse>(
+          `/api/portfolio/${portfolioId}`,
+        )
+
+        setPortfolio(data.data)
+      } catch (err) {
+        if (axios.isAxiosError(err)) {
+          const status = err.response?.status
+          if (status === 400) setError('인증이 만료되었어요. 다시 로그인해 주세요.')
+          else if (status === 404) setError('포트폴리오를 찾을 수 없어요.')
+          else setError('포트폴리오 상세 정보를 불러오지 못했어요.')
+        } else {
+          setError('알 수 없는 오류가 발생했어요.')
+        }
+      } finally {
+        setIsLoading(false)
+      }
+    }
+
+    fetchPortfolio()
+  }, [portfolioId])
+
+  return { portfolio, isLoading, error }
+}

--- a/src/hooks/usePortfolios.ts
+++ b/src/hooks/usePortfolios.ts
@@ -1,0 +1,79 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import axios from 'axios'
+import axiosInstance from '@/lib/api/axios'
+
+export interface PortfolioSummary {
+  portfolioId: number | string
+  title: string
+  templateId: number | string
+  featuredProjectName: string
+  createdAt: string
+  updatedAt: string
+  isPublic: boolean
+}
+
+interface PortfolioListResponse {
+  success: boolean
+  data: {
+    content: PortfolioSummary[]
+    page: number
+    perPage: number
+    totalElements: number
+    totalPages: number
+  }
+}
+
+export const usePortfolios = () => {
+  const [portfolios, setPortfolios] = useState<PortfolioSummary[]>([])
+  const [page, setPage] = useState(1)
+  const [totalPages, setTotalPages] = useState(1)
+  const [totalElements, setTotalElements] = useState(0)
+  const [isLoading, setIsLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    const fetchPortfolios = async () => {
+      setIsLoading(true)
+      setError(null)
+
+      try {
+        const { data } = await axiosInstance.get<PortfolioListResponse>('/api/portfolio', {
+          params: {
+            page,
+            perPage: 6,
+            sort: 'createdAt',
+            direction: 'desc',
+          },
+        })
+
+        setPortfolios(data.data.content)
+        setTotalPages(data.data.totalPages)
+        setTotalElements(data.data.totalElements)
+      } catch (err) {
+        if (axios.isAxiosError(err)) {
+          const status = err.response?.status
+          if (status === 400) setError('인증이 만료되었어요. 다시 로그인해 주세요.')
+          else setError('포트폴리오 목록을 불러오지 못했어요.')
+        } else {
+          setError('알 수 없는 오류가 발생했어요.')
+        }
+      } finally {
+        setIsLoading(false)
+      }
+    }
+
+    fetchPortfolios()
+  }, [page])
+
+  return {
+    portfolios,
+    page,
+    totalPages,
+    totalElements,
+    isLoading,
+    error,
+    setPage,
+  }
+}

--- a/src/lib/date.ts
+++ b/src/lib/date.ts
@@ -1,0 +1,12 @@
+export const formatKoreanDate = (value?: string) => {
+  if (!value) return '-'
+
+  const date = new Date(value)
+  if (Number.isNaN(date.getTime())) return value
+
+  return new Intl.DateTimeFormat('ko-KR', {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+  }).format(date)
+}


### PR DESCRIPTION

- **관련 이슈**: #32 
---

## 작업 내용

- 마이페이지(`/home/my`) 화면을 추가했습니다.
- 로그인한 유저 정보와 포트폴리오 요약 정보를 표시합니다.
- 내 포트폴리오 목록 조회 API를 연동했습니다.
  - `GET /api/portfolio`
- 포트폴리오 상세 화면을 추가했습니다.
  - `/home/my/portfolios/[portfolioId]`
- 포트폴리오 상세 조회 API를 연동했습니다.
  - `GET /api/portfolio/{portfolioId}`
- 날짜 표시 공통 유틸을 추가했습니다.

## 확인 사항

- 로컬에서는 인증/서버 환경 차이로 포트폴리오 목록 API가 실패하여 에러 상태 화면만 확인했습니다.
- 실제 포트폴리오 데이터 렌더링은 develop 서버 환경에서 확인이 필요합니다.
- 에러 상태, 빈 상태, 로딩 상태 UI를 함께 처리했습니다.
