### PR TITLE
fix: 헤더 로그인 상태에 따른 버튼 및 로고 링크 변경 

### DIFF
--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -1,18 +1,49 @@
+'use client'
+
 import Logo from '@/components/layout/Logo'
 import { Button } from '@/components/ui/button'
 import Link from 'next/link'
+import { useEffect, useState } from 'react'
+import { usePathname, useRouter } from 'next/navigation'
 
 export default function Header() {
+  const [isLoggedIn, setIsLoggedIn] = useState(false)
+  const pathname = usePathname()
+  const router = useRouter()
+
+  useEffect(() => {
+    const token = localStorage.getItem('accessToken')
+    setIsLoggedIn(!!token)
+  }, [pathname])
+
+  function handleLogout() {
+    localStorage.clear()
+    router.push('/login')
+  }
+
   return (
     <header className="flex items-center justify-between px-6 py-4 border-b">
       <Logo />
       <div className="flex gap-2">
-        <Button asChild variant="primary" size="sm">
-          <Link href="/login">로그인</Link>
-        </Button>
-        <Button asChild variant="primaryOutline" size="sm">
-          <Link href="/signup">회원가입</Link>
-        </Button>
+        {isLoggedIn ? (
+          <>
+            <Button asChild variant="primary" size="sm">
+              <Link href="/home/my">마이페이지</Link>
+            </Button>
+            <Button variant="primaryOutline" size="sm" onClick={handleLogout}>
+              로그아웃
+            </Button>
+          </>
+        ) : (
+          <>
+            <Button asChild variant="primary" size="sm">
+              <Link href="/login">로그인</Link>
+            </Button>
+            <Button asChild variant="primaryOutline" size="sm">
+              <Link href="/signup">회원가입</Link>
+            </Button>
+          </>
+        )}
       </div>
     </header>
   )

--- a/src/components/layout/Logo.tsx
+++ b/src/components/layout/Logo.tsx
@@ -1,9 +1,21 @@
+'use client'
+
 import Link from 'next/link'
 import Image from 'next/image'
+import { useEffect, useState } from 'react'
+import { usePathname } from 'next/navigation'
 
 export default function Logo() {
+  const [isLoggedIn, setIsLoggedIn] = useState(false)
+  const pathname = usePathname()
+
+  useEffect(() => {
+    const token = localStorage.getItem('accessToken')
+    setIsLoggedIn(!!token)
+  }, [pathname])
+
   return (
-    <Link href="/" className="flex items-center gap-2">
+    <Link href={isLoggedIn ? '/home' : '/'} className="flex items-center gap-2">
       <Image src="/logo.svg" alt="로고" width={36} height={36} />
       <span className="font-archivo-black tracking-[-0.05em] text-[#1C3154]">
         AutoPort


### PR DESCRIPTION
## 📌 개요

- **작업 요약**: 로그인 상태에 따라 헤더 버튼 및 로고 링크를 다르게 표시

---

## 🔍 주요 구현 내용

- **[헤더 버튼 분기]**: 로그인 상태면 마이페이지/로그아웃 버튼, 비로그인 상태면 로그인/회원가입 버튼 표시
- **[로그아웃 기능]**: 로그아웃 버튼 클릭 시 localStorage 초기화 후 /login으로 이동
- **[로고 링크 분기]**: 로그인 상태면 /home, 비로그인 상태면 /로 이동

---

## 📸 실행 결과 (이미지/GIF)

[로그아웃 상태]
<img width="2559" height="1342" alt="image" src="https://github.com/user-attachments/assets/7906b6c4-848f-4cbc-b04c-b793765e6800" />

[로그인 상태]