### PR TITLE
[Feat] 포트폴리오 저장 API 연결

### DIFF
--- a/src/hooks/useGeneratePortfolio.ts
+++ b/src/hooks/useGeneratePortfolio.ts
@@ -3,6 +3,9 @@ import { useRouter } from 'next/navigation'
 import axios from 'axios'
 import axiosInstance from '@/lib/api/axios'
 import { useRepoStore } from '@/store/repoStore'
+import { createPortfolio } from '@/lib/api/portfolio'
+import type { CreatePortfolioRequest } from '@/types/portfolio'
+import type { AnalyzeResult } from '@/store/repoStore'
 
 export interface PortfolioResult {
   portfolioTitle: string
@@ -23,6 +26,36 @@ export interface PortfolioResult {
   generatedAt: string
 }
 
+const DEFAULT_TEMPLATE_ID = 1
+
+const toDraftPortfolioRequest = (
+  result: PortfolioResult,
+  analyzeResult: AnalyzeResult
+): CreatePortfolioRequest => {
+  const fallbackProjectName = analyzeResult.aiInputData.projectName || analyzeResult.repoName
+  const fallbackDescription = analyzeResult.aiInputData.description || analyzeResult.description
+  const fallbackTechStacks = analyzeResult.aiInputData.stacks.length > 0
+    ? analyzeResult.aiInputData.stacks
+    : analyzeResult.techStacks
+
+  return {
+    title: result.portfolioTitle,
+    bio: result.introduction,
+    templateId: DEFAULT_TEMPLATE_ID,
+    featuredProjectId: analyzeResult.repoId,
+    isPublic: false,
+    projects: result.projects.map((project, index) => ({
+      repoId: analyzeResult.repoId,
+      name: project.name || fallbackProjectName,
+      description: project.description || project.oneLineDescription || fallbackDescription,
+      techStacks: project.techStacks.length > 0 ? project.techStacks : fallbackTechStacks,
+      highlights: project.highlights.length > 0 ? project.highlights : project.mainFeatures,
+      githubUrl: analyzeResult.aiInputData.repoUrl,
+      order: index + 1,
+    })),
+  }
+}
+
 export const useGeneratePortfolio = () => {
   const [isLoading, setIsLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
@@ -41,7 +74,10 @@ export const useGeneratePortfolio = () => {
         emphasis,
       })
 
-      setPortfolioResult(data.data)
+      const portfolioResult = data.data as PortfolioResult
+      await createPortfolio(toDraftPortfolioRequest(portfolioResult, analyzeResult))
+
+      setPortfolioResult(portfolioResult)
       router.push('/home/repos/analyze/portfolio')
     } catch (err) {
       if (axios.isAxiosError(err)) {

--- a/src/hooks/usePortfolio.ts
+++ b/src/hooks/usePortfolio.ts
@@ -1,11 +1,13 @@
 import { useState, useEffect, useCallback } from 'react'
 import {
+  createPortfolio,
   fetchPortfolioList,
   fetchPortfolioDetail,
   updatePortfolio,
   deletePortfolio,
 } from '@/lib/api/portfolio'
 import type {
+  CreatePortfolioRequest,
   Portfolio,
   PortfolioListItem,
   UpdatePortfolioRequest,
@@ -22,7 +24,7 @@ export function usePortfolioList() {
     setError(null)
     try {
       const data = await fetchPortfolioList({ sort: 'updatedAt', direction: 'desc' })
-      setPortfolios(Array.isArray(data) ? data : (data as any).content ?? [])
+      setPortfolios(data.content)
     } catch (e) {
       setError(e instanceof Error ? e.message : '오류가 발생했습니다.')
     } finally {
@@ -35,6 +37,27 @@ export function usePortfolioList() {
   }, [load])
 
   return { portfolios, loading, error, refetch: load }
+}
+
+// 포트폴리오 생성
+export function useCreatePortfolio() {
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const create = useCallback(async (body: CreatePortfolioRequest) => {
+    setLoading(true)
+    setError(null)
+    try {
+      return await createPortfolio(body)
+    } catch (e) {
+      setError(e instanceof Error ? e.message : '저장에 실패했습니다.')
+      throw e
+    } finally {
+      setLoading(false)
+    }
+  }, [])
+
+  return { create, loading, error }
 }
 
 // 포트폴리오 상세 조회

--- a/src/lib/api/portfolio.ts
+++ b/src/lib/api/portfolio.ts
@@ -1,6 +1,8 @@
 import type {
+  CreatePortfolioRequest,
+  CreatePortfolioResponse,
   Portfolio,
-  PortfolioListItem,
+  PortfolioListResponse,
   UpdatePortfolioRequest,
   UpdatePortfolioResponse,
 } from '@/types/portfolio'
@@ -11,13 +13,34 @@ function getToken() {
   return typeof window !== 'undefined' ? localStorage.getItem('accessToken') : null
 }
 
+// 포트폴리오 생성
+export const createPortfolio = async (
+  data: CreatePortfolioRequest
+): Promise<CreatePortfolioResponse> => {
+  const res = await fetch(`${API_BASE_URL}/api/portfolio`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${getToken()}`,
+    },
+    body: JSON.stringify(data),
+  })
+
+  if (!res.ok) {
+    throw new Error('포트폴리오 저장에 실패했습니다.')
+  }
+
+  const json = await res.json()
+  return json.data
+}
+
 // 포트폴리오 목록 조회
 export const fetchPortfolioList = async (params?: {
   page?: number
   perPage?: number
   sort?: 'createdAt' | 'updatedAt'
   direction?: 'asc' | 'desc'
-}): Promise<PortfolioListItem[]> => {
+}): Promise<PortfolioListResponse> => {
   const query = new URLSearchParams()
   if (params?.page) query.set('page', String(params.page))
   if (params?.perPage) query.set('perPage', String(params.perPage))
@@ -30,7 +53,8 @@ export const fetchPortfolioList = async (params?: {
       Authorization: `Bearer ${getToken()}`,
     },
   })
-  return res.json()
+  const json = await res.json()
+  return json.data
 }
 
 // 포트폴리오 상세 조회

--- a/src/types/portfolio.ts
+++ b/src/types/portfolio.ts
@@ -44,3 +44,27 @@ export interface UpdatePortfolioResponse {
   title: string
   updatedAt: string
 }
+
+export interface PortfolioListResponse {
+  content: PortfolioListItem[]
+  page: number
+  perPage: number
+  totalElements: number
+  totalPages: number
+}
+
+export interface CreatePortfolioRequest {
+  title: string
+  bio: string
+  templateId: number
+  projects: Project[]
+  featuredProjectId?: number
+  isPublic: boolean
+}
+
+export interface CreatePortfolioResponse {
+  portfolioId: number
+  title: string
+  createdAt: string
+  isPublic: boolean
+}


### PR DESCRIPTION
## 📌 개요

- **관련 이슈**: #40 
- **작업 요약**: 포트폴리오 생성 완료 후 생성 결과를 초안으로 자동 저장하도록 저장 API를 연결했습니다.

---

## 🔍 주요 구현 내용

- `POST /api/portfolio` 저장 API를 호출하는 `createPortfolio` 함수를 추가했습니다.
- 포트폴리오 생성 요청/응답 타입을 추가했습니다.
  - `CreatePortfolioRequest`
  - `CreatePortfolioResponse`
- 저장 API를 재사용할 수 있도록 `useCreatePortfolio` 훅을 추가했습니다.
- 기존 포트폴리오 목록 조회 응답 타입을 `PortfolioListResponse`로 정리하고, `data.content` 기준으로 목록을 사용하도록 수정했습니다.
- 포트폴리오 생성 훅(`useGeneratePortfolio`)에서 생성 성공 직후 저장 API를 호출하도록 연결했습니다.
- 생성 API 응답을 저장 API 요청 형식으로 변환하는 매핑 로직을 추가했습니다.
  - `title`: 생성된 포트폴리오 제목
  - `bio`: 생성된 소개 문구
  - `templateId`: 기본값 `1`
  - `featuredProjectId`: 분석한 레포지토리 ID
  - `isPublic`: 초안 저장 목적에 맞춰 `false`
  - `projects`: 생성 결과와 분석 결과를 조합해 `repoId`, `githubUrl`, `techStacks`, `highlights` 등을 구성