### PR TITLE
[Fix] 포트폴리오 저장 API 명세 변경에 따른 수정

### DIFF
--- a/src/hooks/useGeneratePortfolio.ts
+++ b/src/hooks/useGeneratePortfolio.ts
@@ -26,8 +26,6 @@ export interface PortfolioResult {
   generatedAt: string
 }
 
-const DEFAULT_TEMPLATE_ID = 1
-
 const toDraftPortfolioRequest = (
   result: PortfolioResult,
   analyzeResult: AnalyzeResult
@@ -41,7 +39,6 @@ const toDraftPortfolioRequest = (
   return {
     title: result.portfolioTitle,
     bio: result.introduction,
-    templateId: DEFAULT_TEMPLATE_ID,
     featuredProjectId: analyzeResult.repoId,
     isPublic: false,
     projects: result.projects.map((project, index) => ({

--- a/src/types/portfolio.ts
+++ b/src/types/portfolio.ts
@@ -56,7 +56,7 @@ export interface PortfolioListResponse {
 export interface CreatePortfolioRequest {
   title: string
   bio: string
-  templateId: number
+  templateId?: number
   projects: Project[]
   featuredProjectId?: number
   isPublic: boolean


### PR DESCRIPTION
## 📌 개요

- **작업 요약**: 포트폴리오 초안 저장 시 유효하지 않은 `templateId`가 전송되지 않도록 수정했습니다.

---

## 🔍 주요 구현 내용

- 포트폴리오 생성 후 초안 저장 요청에서 `templateId` 기본값 전송을 제거했습니다.
- 백엔드에서 `templateId`는 선택값으로 처리되므로 `CreatePortfolioRequest` 타입도 optional로 수정했습니다.
- 기존에 `templateId: 1`이 고정 전송되어 발생하던 `400 Bad Request` 문제를 해결했습니다.