### PR TITLE
fix: GitHub 로그인 scope 수정

### DIFF
--- a/src/features/auth/components/LoginPage.tsx
+++ b/src/features/auth/components/LoginPage.tsx
@@ -24,7 +24,7 @@ export default function LoginPage() {
   const handleGithubLogin = () => {
     const clientId = process.env.NEXT_PUBLIC_GITHUB_CLIENT_ID
     const redirectUri = `${process.env.NEXT_PUBLIC_FRONTEND_URL}/auth/github/callback`
-    window.location.href = `https://github.com/login/oauth/authorize?client_id=${clientId}&redirect_uri=${redirectUri}&scope=read:user`
+    window.location.href = `https://github.com/login/oauth/authorize?client_id=${clientId}&redirect_uri=${redirectUri}&scope=read:user,repo`
   }
 
   return (


### PR DESCRIPTION
## 📌 개요

- GitHub 로그인 시 repo 스코프 추가로 콜라보레이터 레포도 조회 가능하도록 수정

---

## 🔍 주요 구현 내용

- **[GitHub 로그인 스코프 수정]**: 기존 `read:user` 스코프만 요청하던 것을 `read:user,repo` 로 변경하여 콜라보레이터로 참여한 레포지토리도 조회 가능하도록 수정