### PR TITLE
fix: GitHub 로그인 scope 수정

### DIFF
--- a/src/features/auth/components/LoginPage.tsx
+++ b/src/features/auth/components/LoginPage.tsx
@@ -24,7 +24,7 @@ export default function LoginPage() {
   const handleGithubLogin = () => {
     const clientId = process.env.NEXT_PUBLIC_GITHUB_CLIENT_ID
     const redirectUri = `${process.env.NEXT_PUBLIC_FRONTEND_URL}/auth/github/callback`
-    window.location.href = `https://github.com/login/oauth/authorize?client_id=${clientId}&redirect_uri=${redirectUri}&scope=read:user,repo`
+    window.location.href = `https://github.com/login/oauth/authorize?client_id=${clientId}&redirect_uri=${redirectUri}&scope=read:user,repo,read:org`
   }
 
   return (

--- a/src/features/auth/components/LoginPage.tsx
+++ b/src/features/auth/components/LoginPage.tsx
@@ -24,7 +24,7 @@ export default function LoginPage() {
   const handleGithubLogin = () => {
     const clientId = process.env.NEXT_PUBLIC_GITHUB_CLIENT_ID
     const redirectUri = `${process.env.NEXT_PUBLIC_FRONTEND_URL}/auth/github/callback`
-    window.location.href = `https://github.com/login/oauth/authorize?client_id=${clientId}&redirect_uri=${redirectUri}&scope=read:user,repo,read:org`
+    window.location.href = `https://github.com/login/oauth/authorize?client_id=${clientId}&redirect_uri=${redirectUri}&scope=read:user,repo,read:org,user:email`
   }
 
   return (


### PR DESCRIPTION
## 📌 개요

- **작업 요약**: GitHub 로그인 OAuth 스코프 추가 (read:org, user:email)

---

## 🔍 주요 구현 내용

> 구현된 기능의 핵심 로직이나 변경된 구조를 상세히 적어주세요.

### 1. 기능 설명

- **[read:org 스코프 추가]**: Organization 레포지토리도 조회 가능하도록 수정
- **[user:email 스코프 추가]**: GitHub 계정 이메일 접근 권한 추가

### 2. 핵심 코드/로직 

- `LoginPage.tsx`의 `handleGithubLogin` 함수에서 scope 파라미터 수정
- 기존: `scope=read:user,repo`
- 변경: `scope=read:user,repo,read:org,user:email`

---