### PR TITLE
feat: 포트폴리오 생성 완료 후 수정하기/보러가기 버튼 추가

### DIFF
--- a/src/app/home/repos/analyze/portfolio/page.tsx
+++ b/src/app/home/repos/analyze/portfolio/page.tsx
@@ -4,7 +4,7 @@ import { useRepoStore } from '@/store/repoStore'
 import { useRouter } from 'next/navigation'
 
 const PortfolioPage = () => {
-  const { portfolioResult } = useRepoStore()
+  const { portfolioResult, savedPortfolioId } = useRepoStore()
   const router = useRouter()
 
   if (!portfolioResult) {
@@ -150,14 +150,22 @@ const PortfolioPage = () => {
       </div>
 
       {/* CTA */}
-      <div className="flex w-full max-w-2xl flex-col items-center gap-3">
+      <div className="flex w-full max-w-2xl flex-col gap-3">
+        {savedPortfolioId && (
         <button
-          onClick={() => router.push('/home')}
-          className="body-sb w-full rounded-2xl bg-neutral-900 py-5 text-white transition-all hover:bg-neutral-800"
+          onClick={() => router.push(`/portfolio/${savedPortfolioId}/edit`)}
+          className="body-sb w-full rounded-2xl border border-neutral-900 py-5 text-neutral-900 transition-all hover:bg-neutral-50"
         >
-          내 포트폴리오 보러가기
+          수정하기
         </button>
-      </div>
+      )}
+      <button
+        onClick={() => router.push('/home/my')}
+        className="body-sb w-full rounded-2xl bg-neutral-900 py-5 text-white transition-all hover:bg-neutral-800"
+      >
+        내 포트폴리오 보러가기
+      </button>
+    </div>
     </div>
   )
 }

--- a/src/hooks/useGeneratePortfolio.ts
+++ b/src/hooks/useGeneratePortfolio.ts
@@ -56,7 +56,7 @@ const toDraftPortfolioRequest = (
 export const useGeneratePortfolio = () => {
   const [isLoading, setIsLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
-  const { analyzeResult, setPortfolioResult } = useRepoStore()
+  const { analyzeResult, setPortfolioResult, setSavedPortfolioId } = useRepoStore()
   const router = useRouter()
 
   const generate = async (emphasis: string, userName: string) => {
@@ -72,9 +72,10 @@ export const useGeneratePortfolio = () => {
       })
 
       const portfolioResult = data.data as PortfolioResult
-      await createPortfolio(toDraftPortfolioRequest(portfolioResult, analyzeResult))
+      const created = await createPortfolio(toDraftPortfolioRequest(portfolioResult, analyzeResult))
 
       setPortfolioResult(portfolioResult)
+      setSavedPortfolioId(created.portfolioId)
       router.push('/home/repos/analyze/portfolio')
     } catch (err) {
       if (axios.isAxiosError(err)) {

--- a/src/store/repoStore.ts
+++ b/src/store/repoStore.ts
@@ -1,5 +1,6 @@
 import { create } from 'zustand'
 import { PortfolioResult } from '@/hooks/useGeneratePortfolio'
+
 export interface Repo {
   repoId: number
   name: string
@@ -54,10 +55,12 @@ interface RepoStore {
   selectedRepo: Repo | null
   analyzeResult: AnalyzeResult | null
   portfolioResult: PortfolioResult | null
+  savedPortfolioId: number | null
   setRepos: (repos: Repo[]) => void
   setSelectedRepo: (repo: Repo) => void
   setAnalyzeResult: (result: AnalyzeResult) => void
   setPortfolioResult: (result: PortfolioResult) => void
+  setSavedPortfolioId: (id: number) => void
 }
 
 export const useRepoStore = create<RepoStore>((set) => ({
@@ -65,8 +68,10 @@ export const useRepoStore = create<RepoStore>((set) => ({
   selectedRepo: null,
   analyzeResult: null,
   portfolioResult: null,
+  savedPortfolioId: null,
   setRepos: (repos) => set({ repos }),
   setSelectedRepo: (repo) => set({ selectedRepo: repo }),
   setAnalyzeResult: (result) => set({ analyzeResult: result }),
   setPortfolioResult: (result) => set({ portfolioResult: result }),
+  setSavedPortfolioId: (id) => set({ savedPortfolioId: id }),
 }))


### PR DESCRIPTION
## 📌 개요
- **관련 이슈**: #33
- **작업 요약**: 포트폴리오 생성 완료 화면에 수정하기/보러가기 버튼 추가 및 저장된 portfolioId store 연동

---
## 🔍 주요 구현 내용

- **[수정하기 버튼 추가]**: 생성 완료 화면에서 수정하기 버튼 클릭 시 `/portfolio/{portfolioId}/edit` 으로 이동
- **[내 포트폴리오 보러가기 버튼 수정]**: 기존 `/home` 에서 `/home/my` 로 이동하도록 변경