### PR TITLE
fix: 포트폴리오 상세 조회/수정 API 응답 처리 및 편집 페이지 개선

### DIFF
--- a/src/lib/api/portfolio.ts
+++ b/src/lib/api/portfolio.ts
@@ -66,7 +66,7 @@ export const fetchPortfolioDetail = async (portfolioId: number): Promise<Portfol
     },
   })
   const json = await res.json()
-  return json.data  
+  return json.data
 }
 
 // 포트폴리오 수정
@@ -82,7 +82,8 @@ export const updatePortfolio = async (
     },
     body: JSON.stringify(data),
   })
-  return res.json()
+  const json = await res.json()
+  return json.data
 }
 
 // 포트폴리오 삭제

--- a/src/lib/api/portfolio.ts
+++ b/src/lib/api/portfolio.ts
@@ -65,7 +65,8 @@ export const fetchPortfolioDetail = async (portfolioId: number): Promise<Portfol
       Authorization: `Bearer ${getToken()}`,
     },
   })
-  return res.json()
+  const json = await res.json()
+  return json.data  
 }
 
 // 포트폴리오 수정

--- a/src/types/portfolio.ts
+++ b/src/types/portfolio.ts
@@ -14,6 +14,7 @@ export interface Portfolio {
   bio: string
   templateId: number
   public: boolean
+  isPublic: boolean
   featuredProjectId?: number
   projects: Project[]
   createdAt: string


### PR DESCRIPTION
## 📌 개요
- **관련 이슈**: #33
- **작업 요약**: 포트폴리오 상세 조회/수정 API 응답 처리 수정 및 편집 페이지 데이터 로드 개선

---
## 🔍 주요 구현 내용

- **[API 응답 처리 수정]**: 백엔드 응답이 `{ success, data }` 구조로 오는데 `data` 필드를 추출하지 않아 편집 페이지에 데이터가 안 뜨는 문제 수정
- **[Portfolio 타입 수정]**: 백엔드 응답에 `isPublic` 필드가 있는데 타입에 없어서 추가
- **[수정하기/보러가기 버튼 추가]**: 생성 완료 화면에서 수정하기 버튼 클릭 시 편집 페이지로 이동, 보러가기 버튼은 마이페이지로 이동
- **[savedPortfolioId store 추가]**: 포트폴리오 생성 후 반환된 portfolioId를 store에 저장