### PR TITLE
feat: 포트폴리오 편집 페이지 개선 및 버그 수정

### DIFF
--- a/src/app/contact/page.tsx
+++ b/src/app/contact/page.tsx
@@ -1,0 +1,41 @@
+export default function ContactPage() {
+  return (
+    <div className="flex flex-col min-h-screen px-10 py-16 max-w-3xl mx-auto">
+      <h1 className="title-bold mb-8">문의하기</h1>
+      <div className="flex flex-col gap-6 body-m">
+        <section>
+          <h2 className="title-sb-md mb-2">이메일 문의</h2>
+          <p>서비스 이용 중 불편한 점이나 개선 사항은 아래 이메일로 문의해 주세요.</p>
+          <p className="mt-2 text-neutral-700 font-medium">support@autoport.dev</p>
+        </section>
+        <section>
+          <h2 className="title-sb-md mb-2">문의 가능 시간</h2>
+          <p>평일 오전 10시 ~ 오후 6시 (주말 및 공휴일 제외)</p>
+          <p className="mt-1 text-neutral-500">접수된 문의는 영업일 기준 1~3일 이내에 답변 드립니다.</p>
+        </section>
+        <section>
+          <h2 className="title-sb-md mb-2">자주 묻는 질문</h2>
+          <ul className="flex flex-col gap-3 mt-1">
+            <li>
+              <p className="font-medium text-neutral-800">Q. 포트폴리오 생성은 무료인가요?</p>
+              <p className="mt-0.5 text-neutral-500">A. 네, AutoPort의 기본 포트폴리오 생성 기능은 무료로 제공됩니다.</p>
+            </li>
+            <li>
+              <p className="font-medium text-neutral-800">Q. 비공개로 설정한 포트폴리오는 누가 볼 수 있나요?</p>
+              <p className="mt-0.5 text-neutral-500">A. 비공개 포트폴리오는 본인만 열람할 수 있습니다.</p>
+            </li>
+            <li>
+              <p className="font-medium text-neutral-800">Q. 깃허브 계정 연동은 어떻게 하나요?</p>
+              <p className="mt-0.5 text-neutral-500">A. 회원가입 또는 로그인 시 GitHub OAuth를 통해 자동으로 연동됩니다.</p>
+            </li>
+          </ul>
+        </section>
+        <section>
+          <h2 className="title-sb-md mb-2">버그 및 오류 신고</h2>
+          <p>서비스 이용 중 버그나 오류를 발견하셨다면 이메일 또는 GitHub 이슈로 제보해 주세요.</p>
+          <p className="mt-2 text-neutral-500">빠른 시일 내에 확인 후 조치하겠습니다.</p>
+        </section>
+      </div>
+    </div>
+  )
+}

--- a/src/app/privacy/page.tsx
+++ b/src/app/privacy/page.tsx
@@ -1,0 +1,48 @@
+export default function PrivacyPage() {
+  return (
+    <div className="flex flex-col min-h-screen px-10 py-16 max-w-3xl mx-auto">
+      <h1 className="title-bold mb-8">개인정보처리방침</h1>
+      <div className="flex flex-col gap-6 body-m">
+        <section>
+          <h2 className="title-sb-md mb-2">제1조 (수집하는 개인정보 항목)</h2>
+          <p>AutoPort는 서비스 제공을 위해 다음과 같은 개인정보를 수집합니다.</p>
+          <ul className="mt-2 flex flex-col gap-1 list-disc list-inside text-neutral-600">
+            <li>GitHub 계정 정보 (사용자명, 이메일, 프로필 사진)</li>
+            <li>GitHub 레포지토리 정보 (레포지토리명, 설명, 사용 언어)</li>
+            <li>서비스 이용 기록 및 접속 로그</li>
+          </ul>
+        </section>
+        <section>
+          <h2 className="title-sb-md mb-2">제2조 (개인정보 수집 및 이용 목적)</h2>
+          <p>수집한 개인정보는 다음 목적으로만 활용됩니다.</p>
+          <ul className="mt-2 flex flex-col gap-1 list-disc list-inside text-neutral-600">
+            <li>회원 식별 및 인증</li>
+            <li>포트폴리오 자동 생성 서비스 제공</li>
+            <li>서비스 개선 및 통계 분석</li>
+          </ul>
+        </section>
+        <section>
+          <h2 className="title-sb-md mb-2">제3조 (개인정보 보유 및 이용 기간)</h2>
+          <p>회원 탈퇴 시 또는 수집·이용 목적이 달성된 후 지체 없이 파기합니다. 단, 관계 법령에 따라 보존이 필요한 경우 해당 기간 동안 보관합니다.</p>
+        </section>
+        <section>
+          <h2 className="title-sb-md mb-2">제4조 (개인정보의 제3자 제공)</h2>
+          <p>AutoPort는 수집한 개인정보를 원칙적으로 외부에 제공하지 않습니다. 다만, 이용자가 사전에 동의한 경우 또는 법령에 의해 요구되는 경우에는 예외로 합니다.</p>
+        </section>
+        <section>
+          <h2 className="title-sb-md mb-2">제5조 (이용자의 권리)</h2>
+          <p>이용자는 언제든지 자신의 개인정보를 조회, 수정, 삭제할 수 있으며, 개인정보 처리에 대한 동의를 철회할 수 있습니다. 관련 요청은 고객센터(support@autoport.dev)로 문의해 주세요.</p>
+        </section>
+        <section>
+          <h2 className="title-sb-md mb-2">제6조 (개인정보 보호책임자)</h2>
+          <p>개인정보 처리에 관한 업무를 총괄하고 관련 불만 처리 및 피해구제를 담당합니다.</p>
+          <p className="mt-2 text-neutral-600">이메일: support@autoport.dev</p>
+        </section>
+        <section>
+          <h2 className="title-sb-md mb-2">부칙</h2>
+          <p className="text-neutral-500">본 방침은 2025년 1월 1일부터 시행됩니다.</p>
+        </section>
+      </div>
+    </div>
+  )
+}

--- a/src/features/portfolio/components/PortfolioEditPage.tsx
+++ b/src/features/portfolio/components/PortfolioEditPage.tsx
@@ -146,7 +146,7 @@ export default function PortfolioEditPage({ portfolioId }: { portfolioId: number
     bio: '',
     templateId: 1,
     projects: [],
-    public: true,
+    isPublic: true,
     featuredProjectId: undefined,
   })
   const [toast, setToast] = useState<{ message: string; type: 'success' | 'error' } | null>(null)
@@ -158,7 +158,7 @@ export default function PortfolioEditPage({ portfolioId }: { portfolioId: number
       bio: portfolio.bio ?? '',
       templateId: portfolio.templateId ?? 1,
       projects: portfolio.projects ?? [],
-      public: portfolio.isPublic,
+      isPublic: portfolio.isPublic,
       featuredProjectId: portfolio.featuredProjectId,
     })
   }, [portfolio])
@@ -265,14 +265,14 @@ export default function PortfolioEditPage({ portfolioId }: { portfolioId: number
             <label className="relative inline-flex items-center cursor-pointer">
               <input
                 type="checkbox"
-                checked={form.public ?? true}
-                onChange={(e) => setForm((p) => ({ ...p, public: e.target.checked }))}
+                checked={form.isPublic ?? true}
+                onChange={(e) => setForm((p) => ({ ...p, isPublic: e.target.checked }))}
                 className="sr-only peer"
               />
               <div className="w-10 h-6 bg-neutral-200 rounded-full peer peer-checked:bg-neutral-900 transition" />
               <div className="absolute left-1 top-1 w-4 h-4 bg-white rounded-full transition-all peer-checked:translate-x-4 shadow-sm" />
             </label>
-            <span className="body-m text-neutral-600">{form.public ? '공개' : '비공개'}</span>
+            <span className="body-m text-neutral-600">{form.isPublic ? '공개' : '비공개'}</span>
           </div>
         </div>
 

--- a/src/types/portfolio.ts
+++ b/src/types/portfolio.ts
@@ -14,7 +14,6 @@ export interface Portfolio {
   title: string
   bio: string
   templateId: number
-  public: boolean
   isPublic: boolean
   featuredProjectId?: number
   projects: Project[]
@@ -37,7 +36,7 @@ export interface UpdatePortfolioRequest {
   bio: string
   templateId: number
   projects: Project[]
-  public?: boolean
+  isPublic?: boolean
   featuredProjectId?: number
 }
 


### PR DESCRIPTION
## 📌 개요
- **관련 이슈**: #33
- **작업 요약**: 공개/비공개 버그 수정, contact/privacy 페이지 추가

---
## 🔍 주요 구현 내용

### 1. 기능 설명
- **[공개/비공개 버그 수정]**: isPublic 필드명 불일치로 공개 설정이 저장되지 않던 문제 수정
- **[contact/privacy 페이지 추가]**: 푸터 링크 404 오류 해결을 위해 문의하기, 개인정보처리방침 페이지 추가

### 2. 핵심 코드/로직
- `src/types/portfolio.ts`: Project에 `deployUrl?: string` 추가, Portfolio 응답 타입 `isPublic`으로 통일
- `src/lib/api/portfolio.ts`: UpdatePortfolioRequest의 `public` → `isPublic` 수정