### PR TITLE
feat: 포트폴리오 편집 페이지 개선

### DIFF
--- a/src/features/portfolio/components/PortfolioEditPage.tsx
+++ b/src/features/portfolio/components/PortfolioEditPage.tsx
@@ -20,6 +20,17 @@ function ProjectEditor({
   isFeatured: boolean
   onSetFeatured: () => void
 }) {
+  const [rawTechStacks, setRawTechStacks] = useState(() => (project.techStacks ?? []).join(', '))
+  const [rawHighlights, setRawHighlights] = useState(() => (project.highlights ?? []).join(', '))
+
+  useEffect(() => {
+    setRawTechStacks((project.techStacks ?? []).join(', '))
+  }, [project.repoId])
+
+  useEffect(() => {
+    setRawHighlights((project.highlights ?? []).join(', '))
+  }, [project.repoId])
+
   function update<K extends keyof Project>(key: K, value: Project[K]) {
     onChange({ ...project, [key]: value })
   }
@@ -94,8 +105,8 @@ function ProjectEditor({
             기술 스택 <span className="text-neutral-300">(쉼표로 구분)</span>
           </span>
           <input
-            value={(project.techStacks ?? []).join(', ')}
-            onChange={(e) => handleArrayInput('techStacks', e.target.value)}
+            value={rawTechStacks}
+            onChange={(e) => { setRawTechStacks(e.target.value); handleArrayInput('techStacks', e.target.value) }}
             placeholder="Java, Spring Boot, MySQL"
             className="body-m mt-1 w-full rounded-xl border border-neutral-200 bg-neutral-50 px-4 py-3 text-neutral-700 focus:outline-none focus:border-neutral-400"
           />
@@ -115,8 +126,8 @@ function ProjectEditor({
             주요 기능 <span className="text-neutral-300">(쉼표로 구분)</span>
           </span>
           <input
-            value={(project.highlights ?? []).join(', ')}
-            onChange={(e) => handleArrayInput('highlights', e.target.value)}
+            value={rawHighlights}
+            onChange={(e) => { setRawHighlights(e.target.value); handleArrayInput('highlights', e.target.value) }}
             placeholder="GitHub OAuth 로그인, Gemini 기반 생성"
             className="body-m mt-1 w-full rounded-xl border border-neutral-200 bg-neutral-50 px-4 py-3 text-neutral-700 focus:outline-none focus:border-neutral-400"
           />

--- a/src/features/portfolio/components/PortfolioEditPage.tsx
+++ b/src/features/portfolio/components/PortfolioEditPage.tsx
@@ -125,11 +125,12 @@ function ProjectEditor({
           <span className="caption-m-sm text-neutral-400">
             주요 기능 <span className="text-neutral-300">(쉼표로 구분)</span>
           </span>
-          <input
+          <textarea
             value={rawHighlights}
             onChange={(e) => { setRawHighlights(e.target.value); handleArrayInput('highlights', e.target.value) }}
             placeholder="GitHub OAuth 로그인, Gemini 기반 생성"
-            className="body-m mt-1 w-full rounded-xl border border-neutral-200 bg-neutral-50 px-4 py-3 text-neutral-700 focus:outline-none focus:border-neutral-400"
+            rows={3}
+            className="body-m mt-1 w-full rounded-xl border border-neutral-200 bg-neutral-50 px-4 py-3 text-neutral-700 focus:outline-none focus:border-neutral-400 resize-none"
           />
           {(project.highlights ?? []).length > 0 && (
             <ul className="mt-2 flex flex-col gap-1.5">

--- a/src/features/portfolio/components/PortfolioListPage.tsx
+++ b/src/features/portfolio/components/PortfolioListPage.tsx
@@ -6,10 +6,12 @@ import { usePortfolioList, useDeletePortfolio } from '@/hooks/usePortfolio'
 import type { PortfolioListItem } from '@/types/portfolio'
 
 function formatDate(iso: string) {
-  return new Date(iso).toLocaleDateString('ko-KR', {
+  return new Date(iso).toLocaleString('ko-KR', {
     year: 'numeric',
     month: 'long',
     day: 'numeric',
+    hour: 'numeric',
+    minute: '2-digit',
   })
 }
 

--- a/src/features/portfolio/components/PortfolioListPage.tsx
+++ b/src/features/portfolio/components/PortfolioListPage.tsx
@@ -74,7 +74,9 @@ function PortfolioCard({
               {portfolio.summary || portfolio.description}
             </p>
           )}
-          <p className="caption-m-sm text-neutral-400">수정일 · {formatDate(portfolio.updatedAt)}</p>
+          {portfolio.updatedAt && (
+            <p className="caption-m-sm text-neutral-400">수정일 · {formatDate(portfolio.updatedAt)}</p>
+          )}
         </div>
         <span
           className={`caption-m-sm shrink-0 rounded-full px-3 py-1 ${

--- a/src/types/portfolio.ts
+++ b/src/types/portfolio.ts
@@ -26,13 +26,13 @@ export interface Portfolio {
 export interface PortfolioListItem {
   portfolioId: number
   title: string
-  summary?: string
-  description?: string
-  templateId: number
+  summary: string
+  description: string
   isPublic: boolean
-  featuredProjectName?: string
   createdAt: string
-  updatedAt: string
+  updatedAt?: string
+  templateId?: number
+  featuredProjectName?: string
 }
 
 export interface UpdatePortfolioRequest {


### PR DESCRIPTION
## 📌 개요

- **관련 이슈**: #33
- **작업 요약**: 포트폴리오 편집/목록 페이지 개선 및 다수 버그 수정

---
## 🔍 주요 구현 내용

- **[목록 카드 개선]**: 프로젝트명, summary, 수정일+시간 표시
- **[기술스택/주요기능 입력 개선]**: 콤마 입력 가능하도록 raw string으로 관리, 실시간 태그 미리보기
- **[주요기능 입력창 높이]**: 최소 3줄 보이도록 수정
