### PR TITLE
feat: 포트폴리오 목록 공유 버튼 추가

### DIFF
--- a/src/features/portfolio/components/PortfolioListPage.tsx
+++ b/src/features/portfolio/components/PortfolioListPage.tsx
@@ -130,7 +130,8 @@ export default function PortfolioListPage() {
   }
 
   async function handleShare(portfolioId: number) {
-    const url = `https://autoport-fe-git-develop.vercel.app/portfolio/${portfolioId}`
+    const baseUrl = process.env.NEXT_PUBLIC_FRONTEND_URL || 'https://autoport-fe-git-develop.vercel.app'
+    const url = `${baseUrl}/portfolio/${portfolioId}`
     try {
       await navigator.clipboard.writeText(url)
       showToast('링크가 복사되었습니다!')

--- a/src/features/portfolio/components/PortfolioListPage.tsx
+++ b/src/features/portfolio/components/PortfolioListPage.tsx
@@ -59,10 +59,12 @@ function PortfolioCard({
   portfolio,
   onEdit,
   onDelete,
+  onShare,
 }: {
   portfolio: PortfolioListItem
   onEdit: () => void
   onDelete: () => void
+  onShare: () => void
 }) {
   return (
     <div className="flex flex-col gap-4 rounded-2xl border border-neutral-200 p-6">
@@ -98,6 +100,13 @@ function PortfolioCard({
           편집
         </button>
         <button
+          onClick={onShare}
+          disabled={!portfolio.isPublic}
+          className="body-m flex-1 rounded-xl border border-neutral-200 py-2.5 text-neutral-700 hover:bg-neutral-50 transition disabled:opacity-40 disabled:hover:bg-transparent disabled:cursor-not-allowed"
+        >
+          공유
+        </button>
+        <button
           onClick={onDelete}
           className="body-m flex-1 rounded-xl border border-red-100 py-2.5 text-red-400 hover:bg-red-50 transition"
         >
@@ -113,6 +122,22 @@ export default function PortfolioListPage() {
   const { portfolios, loading, error, refetch } = usePortfolioList()
   const { remove, loading: deleting } = useDeletePortfolio()
   const [deleteTarget, setDeleteTarget] = useState<PortfolioListItem | null>(null)
+  const [toast, setToast] = useState<string | null>(null)
+
+  function showToast(message: string) {
+    setToast(message)
+    setTimeout(() => setToast(null), 3000)
+  }
+
+  async function handleShare(portfolioId: number) {
+    const url = `https://autoport-fe-git-develop.vercel.app/portfolio/${portfolioId}`
+    try {
+      await navigator.clipboard.writeText(url)
+      showToast('링크가 복사되었습니다!')
+    } catch {
+      showToast('링크 복사에 실패했습니다.')
+    }
+  }
 
   async function handleDelete() {
     if (!deleteTarget) return
@@ -150,6 +175,12 @@ export default function PortfolioListPage() {
 
   return (
     <div className="flex w-full flex-col items-center gap-10 px-6 py-12">
+      {toast && (
+        <div className="fixed top-6 left-1/2 -translate-x-1/2 z-50 rounded-xl bg-neutral-900 px-6 py-3 text-white shadow-lg body-m">
+          {toast}
+        </div>
+      )}
+
       <div className="flex w-full max-w-2xl flex-col gap-1">
         <h1 className="title-bold text-neutral-950">내 포트폴리오</h1>
         <p className="body-m text-neutral-500">{portfolios.length}개의 포트폴리오</p>
@@ -170,6 +201,7 @@ export default function PortfolioListPage() {
               portfolio={p}
               onEdit={() => router.push(`/portfolio/${p.portfolioId}/edit`)}
               onDelete={() => setDeleteTarget(p)}
+              onShare={() => handleShare(p.portfolioId)}
             />
           ))
         )}


### PR DESCRIPTION
## 📌 개요
- **관련 이슈**: #59
- **작업 요약**: 포트폴리오 목록 카드에 공유 버튼 추가 및 클립보드 URL 복사 기능 구현

---
## 🔍 주요 구현 내용

### 1. 기능 설명
- **[공유 버튼 추가]**: 포트폴리오 카드에 공유 버튼 추가, 비공개 포트폴리오는 비활성화
- **[클립보드 복사]**: 공유 버튼 클릭 시 포트폴리오 URL을 클립보드에 복사
- **[토스트 메시지]**: 복사 성공/실패 시 3초간 토스트 메시지 표시