### PR TITLE
fix: 공유 URL 수정

### DIFF
--- a/src/features/portfolio/components/PortfolioListPage.tsx
+++ b/src/features/portfolio/components/PortfolioListPage.tsx
@@ -130,8 +130,7 @@ export default function PortfolioListPage() {
   }
 
   async function handleShare(portfolioId: number) {
-    const baseUrl = process.env.NEXT_PUBLIC_FRONTEND_URL || 'https://autoport-fe-git-develop.vercel.app'
-    const url = `${baseUrl}/portfolio/${portfolioId}`
+    const url = `${process.env.NEXT_PUBLIC_FRONTEND_URL}/home/my/portfolios/${portfolioId}`
     try {
       await navigator.clipboard.writeText(url)
       showToast('링크가 복사되었습니다!')


### PR DESCRIPTION
## 📌 개요

- **관련 이슈**: #59
- **작업 요약**: 공유 URL 임시 수정 (api 구축 전) - `${process.env.NEXT_PUBLIC_FRONTEND_URL}/home/my/portfolios/${portfolioId}` 