### PR TITLE
[Feat] 마이페이지 UI 수정

### DIFF
--- a/src/app/home/my/page.tsx
+++ b/src/app/home/my/page.tsx
@@ -169,8 +169,8 @@ const MyPage = () => {
                       <h3 className="body-sb line-clamp-2 text-neutral-950">
                         {portfolio.title}
                       </h3>
-                      <p className="body-m mt-2 line-clamp-1 text-neutral-500">
-                        대표 프로젝트: {portfolio.featuredProjectName || '-'}
+                      <p className="body-m mt-2 line-clamp-3 whitespace-pre-line text-neutral-500">
+                        {portfolio.summary || portfolio.description || '프로젝트 요약이 아직 없어요.'}
                       </p>
                     </div>
                   </div>

--- a/src/app/home/my/portfolios/[portfolioId]/page.tsx
+++ b/src/app/home/my/portfolios/[portfolioId]/page.tsx
@@ -1,11 +1,11 @@
 'use client'
 
-import { ArrowLeft, ExternalLink, FolderGit, Lock, Star } from 'lucide-react'
+import { ArrowLeft } from 'lucide-react'
 import Link from 'next/link'
 import { useParams } from 'next/navigation'
 import { Button } from '@/components/ui/button'
+import PortfolioPreview from '@/features/portfolio/components/PortfolioPreview'
 import { usePortfolioDetail } from '@/hooks/usePortfolioDetail'
-import { formatKoreanDate } from '@/lib/date'
 
 const PortfolioDetailPage = () => {
   const params = useParams<{ portfolioId: string }>()
@@ -15,7 +15,7 @@ const PortfolioDetailPage = () => {
   if (isLoading) {
     return (
       <div className="flex w-full justify-center self-start px-6 py-10">
-      <div className="flex w-full max-w-4xl flex-col gap-4 self-start">
+        <div className="flex w-full max-w-4xl flex-col gap-4 self-start">
           <div className="h-8 w-36 animate-pulse rounded bg-neutral-100" />
           <div className="h-44 animate-pulse rounded-lg bg-neutral-100" />
           <div className="h-72 animate-pulse rounded-lg bg-neutral-100" />
@@ -37,10 +37,6 @@ const PortfolioDetailPage = () => {
     )
   }
 
-  const featuredProject = portfolio.projects.find(
-    (project) => String(project.repoId) === String(portfolio.featuredProjectId),
-  )
-
   return (
     <div className="flex w-full justify-center self-start px-6 py-10">
       <div className="flex w-full max-w-4xl flex-col gap-6 self-start">
@@ -51,134 +47,7 @@ const PortfolioDetailPage = () => {
           </Link>
         </Button>
 
-        <section className="rounded-lg border border-neutral-200 bg-white p-6">
-          <div className="flex flex-col gap-6">
-            <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
-              <div className="min-w-0">
-                <span className="caption-m-sm text-neutral-400">
-                  Template {portfolio.templateId}
-                </span>
-                <h1 className="title-bold mt-2 break-keep text-neutral-950">
-                  {portfolio.title}
-                </h1>
-                <p className="body-m mt-3 break-keep leading-relaxed text-neutral-500">
-                  {portfolio.bio || '소개 문구가 아직 없어요.'}
-                </p>
-              </div>
-              <span className="inline-flex w-fit items-center gap-1 rounded-full border border-neutral-200 px-3 py-1.5 text-sm font-medium text-neutral-500">
-                {portfolio.isPublic ? (
-                  <>
-                    <FolderGit size={14} />
-                    Public
-                  </>
-                ) : (
-                  <>
-                    <Lock size={14} />
-                    Private
-                  </>
-                )}
-              </span>
-            </div>
-
-            <div className="grid gap-3 sm:grid-cols-3">
-              <div className="rounded-lg bg-neutral-50 p-4">
-                <span className="caption-m-sm text-neutral-400">생성일</span>
-                <p className="caption-m-lg mt-1 text-neutral-700">
-                  {formatKoreanDate(portfolio.createdAt)}
-                </p>
-              </div>
-              <div className="rounded-lg bg-neutral-50 p-4">
-                <span className="caption-m-sm text-neutral-400">수정일</span>
-                <p className="caption-m-lg mt-1 text-neutral-700">
-                  {formatKoreanDate(portfolio.updatedAt)}
-                </p>
-              </div>
-              <div className="rounded-lg bg-neutral-50 p-4">
-                <span className="caption-m-sm text-neutral-400">프로젝트</span>
-                <p className="caption-m-lg mt-1 text-neutral-700">
-                  {portfolio.projects.length}개
-                </p>
-              </div>
-            </div>
-          </div>
-        </section>
-
-        {featuredProject && (
-          <section className="rounded-lg border border-blue-100 bg-blue-50 p-6">
-            <div className="flex items-center gap-2 text-blue-500">
-              <Star size={16} />
-              <span className="caption-m-sm">대표 프로젝트</span>
-            </div>
-            <h2 className="body-sb mt-4 text-neutral-950">{featuredProject.name}</h2>
-            <p className="body-m mt-2 break-keep text-neutral-600">
-              {featuredProject.description}
-            </p>
-          </section>
-        )}
-
-        <section className="flex flex-col gap-3">
-          <div>
-            <span className="caption-m-sm text-neutral-400">Projects</span>
-            <h2 className="title-sb-md mt-1 text-neutral-950">프로젝트 구성</h2>
-          </div>
-
-          <div className="flex flex-col gap-3">
-            {portfolio.projects.map((project) => (
-              <article
-                key={`${project.repoId}-${project.order}`}
-                className="rounded-lg border border-neutral-200 bg-white p-5"
-              >
-                <div className="flex flex-col gap-4">
-                  <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
-                    <div>
-                      <span className="caption-m-sm text-neutral-400">
-                        Project {project.order}
-                      </span>
-                      <h3 className="body-sb mt-1 text-neutral-950">{project.name}</h3>
-                    </div>
-                    {project.githubUrl && (
-                      <Button asChild variant="outline" className="h-9 w-fit gap-2 rounded-lg px-3">
-                        <a href={project.githubUrl} target="_blank" rel="noopener noreferrer">
-                          <FolderGit size={15} />
-                          GitHub
-                          <ExternalLink size={14} />
-                        </a>
-                      </Button>
-                    )}
-                  </div>
-
-                  <p className="body-m break-keep leading-relaxed text-neutral-600">
-                    {project.description}
-                  </p>
-
-                  {project.techStacks.length > 0 && (
-                    <div className="flex flex-wrap gap-2">
-                      {project.techStacks.map((stack) => (
-                        <span
-                          key={stack}
-                          className="rounded-full bg-neutral-100 px-3 py-1.5 text-sm font-medium text-neutral-700"
-                        >
-                          {stack}
-                        </span>
-                      ))}
-                    </div>
-                  )}
-
-                  {project.highlights.length > 0 && (
-                    <ul className="flex flex-col gap-2 border-t border-neutral-100 pt-4">
-                      {project.highlights.map((highlight) => (
-                        <li key={highlight} className="body-m flex gap-2 text-neutral-700">
-                          <span className="mt-2 h-1.5 w-1.5 shrink-0 rounded-full bg-neutral-400" />
-                          <span>{highlight}</span>
-                        </li>
-                      ))}
-                    </ul>
-                  )}
-                </div>
-              </article>
-            ))}
-          </div>
-        </section>
+        <PortfolioPreview portfolio={portfolio} />
       </div>
     </div>
   )

--- a/src/app/home/repos/analyze/portfolio/page.tsx
+++ b/src/app/home/repos/analyze/portfolio/page.tsx
@@ -1,16 +1,19 @@
 'use client'
 
+import PortfolioPreview, {
+  type PortfolioPreviewData,
+} from '@/features/portfolio/components/PortfolioPreview'
 import { useRepoStore } from '@/store/repoStore'
 import { useRouter } from 'next/navigation'
 
 const PortfolioPage = () => {
-  const { portfolioResult, savedPortfolioId } = useRepoStore()
+  const { analyzeResult, portfolioResult, savedPortfolioId } = useRepoStore()
   const router = useRouter()
 
   if (!portfolioResult) {
     return (
       <div className="flex flex-1 flex-col items-center justify-center gap-4">
-        <p className="body-m text-neutral-400">포트폴리오 결과가 없습니다.</p>
+        <p className="body-m text-neutral-400">포트폴리오 결과가 없어요.</p>
         <button
           onClick={() => router.push('/home')}
           className="caption-m-sm text-neutral-500 underline underline-offset-4"
@@ -21,151 +24,48 @@ const PortfolioPage = () => {
     )
   }
 
+  const previewPortfolio: PortfolioPreviewData = {
+    title: portfolioResult.portfolioTitle,
+    bio: portfolioResult.introduction,
+    summary: portfolioResult.summary,
+    description: portfolioResult.description,
+    createdAt: portfolioResult.generatedAt,
+    updatedAt: portfolioResult.generatedAt,
+    isPublic: false,
+    projects: portfolioResult.projects.map((project, index) => ({
+      repoId: analyzeResult?.repoId ?? index,
+      name: project.name,
+      description: project.description || project.oneLineDescription,
+      techStacks: project.techStacks,
+      highlights: project.highlights.length > 0 ? project.highlights : project.mainFeatures,
+      githubUrl: analyzeResult?.aiInputData.repoUrl,
+      deployUrl: portfolioResult.projectLinks[index],
+      order: index + 1,
+    })),
+  }
+
   return (
-    <div className="flex w-full flex-col items-center gap-10 px-6 py-12">
-      {/* 헤더 */}
-      <div className="flex w-full max-w-2xl flex-col gap-1">
-        <span className="caption-m-sm text-neutral-400">포트폴리오 생성 완료</span>
-        <h1 className="title-bold text-neutral-950">{portfolioResult.portfolioTitle}</h1>
-        <p className="body-m text-neutral-500">{portfolioResult.introduction}</p>
+    <div className="flex w-full flex-col items-center gap-8 px-6 py-12">
+      <div className="flex w-full max-w-4xl flex-col gap-6">
+        <PortfolioPreview portfolio={previewPortfolio} eyebrow="포트폴리오 생성 완료" />
+
+        <div className="flex w-full flex-col gap-3">
+          {savedPortfolioId && (
+            <button
+              onClick={() => router.push(`/portfolio/${savedPortfolioId}/edit`)}
+              className="body-sb w-full rounded-lg border border-neutral-900 py-4 text-neutral-900 transition-all hover:bg-neutral-50"
+            >
+              수정하기
+            </button>
+          )}
+          <button
+            onClick={() => router.push('/home/my')}
+            className="body-sb w-full rounded-lg bg-neutral-900 py-4 text-white transition-all hover:bg-neutral-800"
+          >
+            내 포트폴리오 보러가기
+          </button>
+        </div>
       </div>
-
-      <div className="flex w-full max-w-2xl flex-col gap-4">
-        {/* 프로젝트 */}
-        {portfolioResult.projects.map((project, i) => (
-          <div key={i} className="flex flex-col gap-4 rounded-2xl border border-neutral-200 p-6">
-            <div className="flex flex-col gap-1">
-              <span className="caption-m-sm text-neutral-400">프로젝트</span>
-              <h2 className="body-sb text-neutral-950">{project.name}</h2>
-              <p className="body-m text-neutral-500">{project.oneLineDescription}</p>
-            </div>
-
-            <p className="body-m leading-relaxed text-neutral-700">{project.description}</p>
-
-            <div className="grid grid-cols-2 gap-3">
-              <div className="rounded-xl bg-neutral-50 p-4">
-                <span className="caption-m-sm text-neutral-400">개발 기간</span>
-                <p className="body-m mt-1 text-neutral-700">{project.estimatedPeriod}</p>
-              </div>
-              <div className="rounded-xl bg-neutral-50 p-4">
-                <span className="caption-m-sm text-neutral-400">역할</span>
-                <p className="body-m mt-1 text-neutral-700">{project.role}</p>
-              </div>
-            </div>
-
-            {/* 기술 스택 */}
-            <div>
-              <span className="caption-m-sm text-neutral-400">기술 스택</span>
-              <div className="mt-2 flex flex-wrap gap-2">
-                {project.techStacks.map((stack) => (
-                  <span key={stack} className="caption-m-sm rounded-full bg-neutral-900 px-3 py-1.5 text-white">
-                    {stack}
-                  </span>
-                ))}
-              </div>
-            </div>
-
-            {/* 주요 기능 */}
-            {project.mainFeatures.length > 0 && (
-              <div>
-                <span className="caption-m-sm text-neutral-400">주요 기능</span>
-                <ul className="mt-2 flex flex-col gap-1.5">
-                  {project.mainFeatures.map((feature, j) => (
-                    <li key={j} className="body-m flex gap-2 text-neutral-700">
-                      <span className="mt-1.5 h-1.5 w-1.5 shrink-0 rounded-full bg-neutral-400" />
-                      {feature}
-                    </li>
-                  ))}
-                </ul>
-              </div>
-            )}
-
-            {/* 하이라이트 */}
-            {project.highlights.length > 0 && (
-              <div>
-                <span className="caption-m-sm text-neutral-400">하이라이트</span>
-                <ul className="mt-2 flex flex-col gap-1.5">
-                  {project.highlights.map((highlight, j) => (
-                    <li key={j} className="body-m flex gap-2 text-neutral-700">
-                      <span className="mt-1.5 h-1.5 w-1.5 shrink-0 rounded-full bg-emerald-400" />
-                      {highlight}
-                    </li>
-                  ))}
-                </ul>
-              </div>
-            )}
-          </div>
-        ))}
-
-        {/* 기술 기여 */}
-        {portfolioResult.technicalContributions.length > 0 && (
-          <div className="rounded-2xl border border-neutral-200 p-6">
-            <span className="caption-m-sm text-neutral-400">기술적 기여</span>
-            <ul className="mt-3 flex flex-col gap-2">
-              {portfolioResult.technicalContributions.map((item, i) => (
-                <li key={i} className="body-m flex gap-2 text-neutral-700">
-                  <span className="mt-1.5 h-1.5 w-1.5 shrink-0 rounded-full bg-neutral-400" />
-                  {item}
-                </li>
-              ))}
-            </ul>
-          </div>
-        )}
-
-        {/* 코드 하이라이트 */}
-        {portfolioResult.codeHighlights.length > 0 && (
-          <div className="rounded-2xl border border-neutral-200 p-6">
-            <span className="caption-m-sm text-neutral-400">코드 하이라이트</span>
-            <ul className="mt-3 flex flex-col gap-2">
-              {portfolioResult.codeHighlights.map((item, i) => (
-                <li key={i} className="caption-m-sm flex gap-3 text-neutral-500">
-                  <span className="shrink-0 text-neutral-300">{String(i + 1).padStart(2, '0')}</span>
-                  {item}
-                </li>
-              ))}
-            </ul>
-          </div>
-        )}
-
-        {/* 프로젝트 링크 */}
-        {portfolioResult.projectLinks.length > 0 && (
-          <div className="rounded-2xl border border-neutral-200 p-6">
-            <span className="caption-m-sm text-neutral-400">프로젝트 링크</span>
-            <ul className="mt-3 flex flex-col gap-2">
-              {portfolioResult.projectLinks.map((link, i) => (
-                <li key={i}>
-                  <a
-                    href={link}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className="body-m text-neutral-700 underline underline-offset-4 hover:text-neutral-950"
-                  >
-                    {link}
-                  </a>
-                </li>
-              ))}
-            </ul>
-          </div>
-        )}
-      </div>
-
-      {/* CTA */}
-      <div className="flex w-full max-w-2xl flex-col gap-3">
-        {savedPortfolioId && (
-        <button
-          onClick={() => router.push(`/portfolio/${savedPortfolioId}/edit`)}
-          className="body-sb w-full rounded-2xl border border-neutral-900 py-5 text-neutral-900 transition-all hover:bg-neutral-50"
-        >
-          수정하기
-        </button>
-      )}
-      <button
-        onClick={() => router.push('/home/my')}
-        className="body-sb w-full rounded-2xl bg-neutral-900 py-5 text-white transition-all hover:bg-neutral-800"
-      >
-        내 포트폴리오 보러가기
-      </button>
-    </div>
     </div>
   )
 }

--- a/src/features/portfolio/components/PortfolioPreview.tsx
+++ b/src/features/portfolio/components/PortfolioPreview.tsx
@@ -1,0 +1,231 @@
+'use client'
+
+import {
+  CalendarDays,
+  ExternalLink,
+  FileText,
+  FolderGit,
+  Link as LinkIcon,
+  Lock,
+  Sparkles,
+} from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import { formatKoreanDate } from '@/lib/date'
+
+export interface PortfolioPreviewProject {
+  repoId?: number | string
+  name: string
+  description?: string
+  techStacks?: string[]
+  highlights?: string[]
+  githubUrl?: string
+  deployUrl?: string
+  order?: number
+}
+
+export interface PortfolioPreviewData {
+  title: string
+  bio?: string
+  summary?: string
+  description?: string
+  templateId?: number | string
+  projects: PortfolioPreviewProject[]
+  createdAt?: string
+  updatedAt?: string
+  isPublic?: boolean
+}
+
+interface PortfolioPreviewProps {
+  portfolio: PortfolioPreviewData
+  eyebrow?: string
+}
+
+export default function PortfolioPreview({ portfolio, eyebrow }: PortfolioPreviewProps) {
+  const hasMeta = portfolio.createdAt || portfolio.updatedAt || portfolio.projects.length > 0
+
+  return (
+    <div className="flex w-full flex-col gap-6">
+      <section className="overflow-hidden rounded-lg border border-neutral-200 bg-white">
+        <div className="h-1.5 bg-neutral-950" />
+        <div className="flex flex-col gap-6">
+          <div className="flex flex-col gap-5 p-6 sm:flex-row sm:items-start sm:justify-between">
+            <div className="min-w-0">
+              <div className="flex flex-wrap items-center gap-2">
+                <span className="caption-m-sm text-neutral-400">
+                  {eyebrow ?? (portfolio.templateId ? `Template ${portfolio.templateId}` : 'Portfolio')}
+                </span>
+                {portfolio.templateId && eyebrow && (
+                  <span className="rounded-full bg-neutral-100 px-2.5 py-1 text-xs font-semibold text-neutral-500">
+                    Template {portfolio.templateId}
+                  </span>
+                )}
+              </div>
+              <h1 className="title-bold mt-2 break-keep text-neutral-950">
+                {portfolio.title}
+              </h1>
+              <p className="body-m mt-3 max-w-3xl whitespace-pre-line break-keep leading-relaxed text-neutral-500">
+                {portfolio.bio || '소개 문구가 아직 없어요.'}
+              </p>
+            </div>
+            {typeof portfolio.isPublic === 'boolean' && (
+              <span className="inline-flex w-fit items-center gap-1 rounded-full border border-neutral-200 px-3 py-1.5 text-sm font-medium text-neutral-500">
+                {portfolio.isPublic ? (
+                  <>
+                    <FolderGit size={14} />
+                    Public
+                  </>
+                ) : (
+                  <>
+                    <Lock size={14} />
+                    Private
+                  </>
+                )}
+              </span>
+            )}
+          </div>
+
+          {hasMeta && (
+            <div className="grid border-t border-neutral-100 sm:grid-cols-3">
+              <div className="flex gap-3 px-6 py-4 sm:border-r sm:border-neutral-100">
+                <CalendarDays className="mt-0.5 shrink-0 text-neutral-300" size={18} />
+                <div>
+                  <span className="caption-m-sm text-neutral-400">생성일</span>
+                  <p className="caption-m-lg mt-1 text-neutral-700">
+                    {formatKoreanDate(portfolio.createdAt)}
+                  </p>
+                </div>
+              </div>
+              <div className="flex gap-3 border-t border-neutral-100 px-6 py-4 sm:border-r sm:border-t-0 sm:border-neutral-100">
+                <Sparkles className="mt-0.5 shrink-0 text-neutral-300" size={18} />
+                <div>
+                  <span className="caption-m-sm text-neutral-400">수정일</span>
+                  <p className="caption-m-lg mt-1 text-neutral-700">
+                    {formatKoreanDate(portfolio.updatedAt)}
+                  </p>
+                </div>
+              </div>
+              <div className="flex gap-3 border-t border-neutral-100 px-6 py-4 sm:border-t-0">
+                <FolderGit className="mt-0.5 shrink-0 text-neutral-300" size={18} />
+                <div>
+                  <span className="caption-m-sm text-neutral-400">프로젝트</span>
+                  <p className="caption-m-lg mt-1 text-neutral-700">
+                    {portfolio.projects.length}개
+                  </p>
+                </div>
+              </div>
+            </div>
+          )}
+        </div>
+      </section>
+
+      {(portfolio.summary || portfolio.description) && (
+        <section className="grid gap-3 md:grid-cols-[0.9fr_1.1fr]">
+          {portfolio.summary && (
+            <div className="rounded-lg border border-blue-100 bg-blue-50 p-5">
+              <div className="flex items-center gap-2 text-blue-600">
+                <FileText size={17} />
+                <span className="caption-m-sm">요약</span>
+              </div>
+              <p className="body-m mt-3 whitespace-pre-line break-keep leading-relaxed text-neutral-700">
+                {portfolio.summary}
+              </p>
+            </div>
+          )}
+          {portfolio.description && (
+            <div className="rounded-lg border border-neutral-200 bg-white p-5">
+              <span className="caption-m-sm text-neutral-400">설명</span>
+              <p className="body-m mt-3 whitespace-pre-line break-keep leading-relaxed text-neutral-700">
+                {portfolio.description}
+              </p>
+            </div>
+          )}
+        </section>
+      )}
+
+      <section className="flex flex-col gap-3">
+        <div>
+          <span className="caption-m-sm text-neutral-400">Projects</span>
+          <h2 className="title-sb-md mt-1 text-neutral-950">프로젝트 구성</h2>
+        </div>
+
+        <div className="flex flex-col gap-3">
+          {portfolio.projects.map((project, index) => (
+            <article
+              key={`${project.repoId ?? project.name}-${project.order ?? index}`}
+              className="rounded-lg border border-neutral-200 bg-white p-5"
+            >
+              <div className="flex flex-col gap-4">
+                <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+                  <div>
+                    <span className="inline-flex w-fit rounded-full bg-neutral-100 px-2.5 py-1 text-xs font-semibold text-neutral-500">
+                      Project {project.order ?? index + 1}
+                    </span>
+                    <h3 className="body-sb mt-1 text-neutral-950">{project.name}</h3>
+                  </div>
+                  {(project.githubUrl || project.deployUrl) && (
+                    <div className="flex flex-wrap gap-2">
+                      {project.githubUrl && (
+                        <Button asChild variant="outline" className="h-9 w-fit gap-2 rounded-lg px-3">
+                          <a href={project.githubUrl} target="_blank" rel="noopener noreferrer">
+                            <FolderGit size={15} />
+                            GitHub
+                            <ExternalLink size={14} />
+                          </a>
+                        </Button>
+                      )}
+                      {project.deployUrl && (
+                        <Button asChild variant="outline" className="h-9 w-fit gap-2 rounded-lg px-3">
+                          <a href={project.deployUrl} target="_blank" rel="noopener noreferrer">
+                            <LinkIcon size={15} />
+                            배포
+                            <ExternalLink size={14} />
+                          </a>
+                        </Button>
+                      )}
+                    </div>
+                  )}
+                </div>
+
+                {project.description && (
+                  <p className="body-m whitespace-pre-line break-keep border-l-2 border-neutral-200 pl-4 leading-relaxed text-neutral-600">
+                    {project.description}
+                  </p>
+                )}
+
+                {(project.techStacks?.length ?? 0) > 0 && (
+                  <div>
+                    <span className="caption-m-sm text-neutral-400">기술 스택</span>
+                    <div className="mt-2 flex flex-wrap gap-2">
+                      {project.techStacks?.map((stack) => (
+                        <span
+                          key={stack}
+                          className="rounded-full bg-neutral-100 px-3 py-1.5 text-sm font-semibold text-neutral-700"
+                        >
+                          {stack}
+                        </span>
+                      ))}
+                    </div>
+                  </div>
+                )}
+
+                {(project.highlights?.length ?? 0) > 0 && (
+                  <div className="border-t border-neutral-100 pt-4">
+                    <span className="caption-m-sm text-neutral-400">하이라이트</span>
+                    <ul className="mt-2 flex flex-col gap-2">
+                      {project.highlights?.map((highlight) => (
+                      <li key={highlight} className="body-m flex gap-2 text-neutral-700">
+                        <span className="mt-2 h-1.5 w-1.5 shrink-0 rounded-full bg-blue-500" />
+                        <span>{highlight}</span>
+                      </li>
+                      ))}
+                    </ul>
+                  </div>
+                )}
+              </div>
+            </article>
+          ))}
+        </div>
+      </section>
+    </div>
+  )
+}

--- a/src/hooks/useGeneratePortfolio.ts
+++ b/src/hooks/useGeneratePortfolio.ts
@@ -52,6 +52,7 @@ const toDraftPortfolioRequest = (
       techStacks: project.techStacks.length > 0 ? project.techStacks : fallbackTechStacks,
       highlights: project.highlights.length > 0 ? project.highlights : project.mainFeatures,
       githubUrl: analyzeResult.aiInputData.repoUrl,
+      deployUrl: result.projectLinks[index],
       order: index + 1,
     })),
   }

--- a/src/hooks/usePortfolioDetail.ts
+++ b/src/hooks/usePortfolioDetail.ts
@@ -10,7 +10,8 @@ export interface PortfolioProject {
   description: string
   techStacks: string[]
   highlights: string[]
-  githubUrl: string
+  githubUrl?: string
+  deployUrl?: string
   order: number
 }
 
@@ -18,8 +19,10 @@ export interface PortfolioDetail {
   portfolioId: number | string
   title: string
   bio: string
+  summary?: string
+  description?: string
   templateId: number | string
-  featuredProjectId: number | string
+  featuredProjectId?: number | string
   projects: PortfolioProject[]
   createdAt: string
   updatedAt: string

--- a/src/hooks/usePortfolios.ts
+++ b/src/hooks/usePortfolios.ts
@@ -7,8 +7,10 @@ import axiosInstance from '@/lib/api/axios'
 export interface PortfolioSummary {
   portfolioId: number | string
   title: string
+  summary?: string
+  description?: string
   templateId: number | string
-  featuredProjectName: string
+  featuredProjectName?: string
   createdAt: string
   updatedAt: string
   isPublic: boolean


### PR DESCRIPTION
## 작업 내용

- 마이페이지 포트폴리오 목록 카드에서 대표 프로젝트 대신 포트폴리오 요약을 보여주도록 수정
  - `summary` 우선 표시
  - `summary`가 없으면 `description` 표시
  - 둘 다 없으면 기본 안내 문구 표시

- 포트폴리오 상세 페이지와 포트폴리오 생성 직후 결과 화면의 UI를 동일하게 정리
  - 공통 프리뷰 컴포넌트로 분리
  - 제목, 소개, 요약, 설명, 프로젝트, 기술 스택, 하이라이트, 링크 표시 방식 통일

- 포트폴리오 상세 조회 응답 필드에 맞춰 타입 보완
  - `summary`, `description`, `deployUrl` 등 상세 화면에서 필요한 필드 반영

- 포트폴리오 생성 결과 데이터를 상세 화면과 동일한 형태로 매핑
  - 생성 직후 화면에서도 저장된 상세 페이지와 같은 레이아웃으로 확인 가능하도록 수정