### PR TITLE
feat: 포트폴리오 공유 API 연동 및 공유 페이지 추가

### DIFF
--- a/src/app/portfolio/share/[shareToken]/page.tsx
+++ b/src/app/portfolio/share/[shareToken]/page.tsx
@@ -1,0 +1,43 @@
+'use client'
+
+import { useParams } from 'next/navigation'
+import PortfolioPreview from '@/features/portfolio/components/PortfolioPreview'
+import { useSharedPortfolio } from '@/hooks/usePortfolioDetail'
+
+const SharedPortfolioPage = () => {
+  const params = useParams<{ shareToken: string }>()
+  const shareToken = params.shareToken
+  const { portfolio, isLoading, error } = useSharedPortfolio(shareToken)
+
+  if (isLoading) {
+    return (
+      <div className="flex w-full justify-center self-start px-6 py-10">
+        <div className="flex w-full max-w-4xl flex-col gap-4 self-start">
+          <div className="h-8 w-36 animate-pulse rounded bg-neutral-100" />
+          <div className="h-44 animate-pulse rounded-lg bg-neutral-100" />
+          <div className="h-72 animate-pulse rounded-lg bg-neutral-100" />
+        </div>
+      </div>
+    )
+  }
+
+  if (error || !portfolio) {
+    return (
+      <div className="flex w-full flex-col items-center justify-center gap-4 self-start px-6 py-20 text-center">
+        <p className="body-m text-neutral-500">
+          {error ?? '포트폴리오를 불러올 수 없어요.'}
+        </p>
+      </div>
+    )
+  }
+
+  return (
+    <div className="flex w-full justify-center self-start px-6 py-10">
+      <div className="flex w-full max-w-4xl flex-col gap-6 self-start">
+        <PortfolioPreview portfolio={portfolio} eyebrow="공유된 포트폴리오" />
+      </div>
+    </div>
+  )
+}
+
+export default SharedPortfolioPage

--- a/src/features/portfolio/components/PortfolioListPage.tsx
+++ b/src/features/portfolio/components/PortfolioListPage.tsx
@@ -3,6 +3,7 @@
 import { useState } from 'react'
 import { useRouter } from 'next/navigation'
 import { usePortfolioList, useDeletePortfolio } from '@/hooks/usePortfolio'
+import { createShareLink } from '@/lib/api/portfolio'
 import type { PortfolioListItem } from '@/types/portfolio'
 
 function formatDate(iso: string) {
@@ -130,9 +131,9 @@ export default function PortfolioListPage() {
   }
 
   async function handleShare(portfolioId: number) {
-    const url = `${process.env.NEXT_PUBLIC_FRONTEND_URL}/home/my/portfolios/${portfolioId}`
     try {
-      await navigator.clipboard.writeText(url)
+      const { shareUrl } = await createShareLink(portfolioId)
+      await navigator.clipboard.writeText(shareUrl)
       showToast('링크가 복사되었습니다!')
     } catch {
       showToast('링크 복사에 실패했습니다.')

--- a/src/hooks/usePortfolioDetail.ts
+++ b/src/hooks/usePortfolioDetail.ts
@@ -34,29 +34,27 @@ interface PortfolioDetailResponse {
   data: PortfolioDetail
 }
 
-export const usePortfolioDetail = (portfolioId: string) => {
+const usePortfolioFetch = (url: string | null, notFoundMessage: string) => {
   const [portfolio, setPortfolio] = useState<PortfolioDetail | null>(null)
   const [isLoading, setIsLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
 
   useEffect(() => {
-    if (!portfolioId) return
+    if (!url) return
 
     const fetchPortfolio = async () => {
       setIsLoading(true)
       setError(null)
 
       try {
-        const { data } = await axiosInstance.get<PortfolioDetailResponse>(
-          `/api/portfolio/${portfolioId}`,
-        )
+        const { data } = await axiosInstance.get<PortfolioDetailResponse>(url)
 
         setPortfolio(data.data)
       } catch (err) {
         if (axios.isAxiosError(err)) {
           const status = err.response?.status
           if (status === 400) setError('인증이 만료되었어요. 다시 로그인해 주세요.')
-          else if (status === 404) setError('포트폴리오를 찾을 수 없어요.')
+          else if (status === 404) setError(notFoundMessage)
           else setError('포트폴리오 상세 정보를 불러오지 못했어요.')
         } else {
           setError('알 수 없는 오류가 발생했어요.')
@@ -67,7 +65,21 @@ export const usePortfolioDetail = (portfolioId: string) => {
     }
 
     fetchPortfolio()
-  }, [portfolioId])
+  }, [url, notFoundMessage])
 
   return { portfolio, isLoading, error }
+}
+
+export const usePortfolioDetail = (portfolioId: string) => {
+  return usePortfolioFetch(
+    portfolioId ? `/api/portfolio/${portfolioId}` : null,
+    '포트폴리오를 찾을 수 없어요.',
+  )
+}
+
+export const useSharedPortfolio = (shareToken: string) => {
+  return usePortfolioFetch(
+    shareToken ? `/api/portfolio/share/${shareToken}` : null,
+    '공유된 포트폴리오를 찾을 수 없어요.',
+  )
 }

--- a/src/lib/api/portfolio.ts
+++ b/src/lib/api/portfolio.ts
@@ -3,6 +3,7 @@ import type {
   CreatePortfolioResponse,
   Portfolio,
   PortfolioListResponse,
+  PortfolioShareResponse,
   UpdatePortfolioRequest,
   UpdatePortfolioResponse,
 } from '@/types/portfolio'
@@ -99,4 +100,30 @@ export const deletePortfolio = async (portfolioId: number): Promise<void> => {
     },
   })
   if (!res.ok) throw new Error('포트폴리오 삭제에 실패했습니다.')
+}
+
+// 포트폴리오 공유 링크 생성
+export const createShareLink = async (portfolioId: number): Promise<PortfolioShareResponse> => {
+  const res = await fetch(`${API_BASE_URL}/api/portfolio/${portfolioId}/share`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${getToken()}`,
+    },
+  })
+  if (!res.ok) throw new Error('공유 링크 생성에 실패했습니다.')
+  const json = await res.json()
+  return json.data
+}
+
+// 공유된 포트폴리오 조회 (비로그인)
+export const fetchSharedPortfolio = async (shareToken: string): Promise<Portfolio> => {
+  const res = await fetch(`${API_BASE_URL}/api/portfolio/share/${shareToken}`, {
+    headers: {
+      'Content-Type': 'application/json',
+    },
+  })
+  if (!res.ok) throw new Error('포트폴리오를 불러오는데 실패했습니다.')
+  const json = await res.json()
+  return json.data
 }

--- a/src/types/portfolio.ts
+++ b/src/types/portfolio.ts
@@ -78,3 +78,10 @@ export interface CreatePortfolioResponse {
   createdAt: string
   isPublic: boolean
 }
+
+export interface PortfolioShareResponse {
+  portfolioId: number
+  shareToken: string
+  shareUrl: string
+  isPublic: boolean
+}


### PR DESCRIPTION
## 📌 개요

- **관련 이슈**: #59
- **작업 요약**: 포트폴리오 공유 API 연동 및 비로그인 공유 페이지 추가

---

## 🔍 주요 구현 내용

- 공유 링크 생성: 공유 버튼 클릭 시 POST /api/portfolio/{portfolioId}/share 호출 후 반환된 shareUrl 클립보드 복사
- 비공개 시 비활성화: isPublic === false인 포트폴리오는 공유 버튼 비활성화
- 공유 페이지 추가: /portfolio/share/:shareToken 라우트 신규 생성, 비로그인 접근 가능하며 GET /api/portfolio/share/{shareToken} 호출로 포트폴리오 조회