### PR TITLE
fix: 공유 URL 수정 

### DIFF
--- a/src/features/portfolio/components/PortfolioListPage.tsx
+++ b/src/features/portfolio/components/PortfolioListPage.tsx
@@ -132,7 +132,8 @@ export default function PortfolioListPage() {
 
   async function handleShare(portfolioId: number) {
     try {
-      const { shareUrl } = await createShareLink(portfolioId)
+      const { shareToken } = await createShareLink(portfolioId)
+      const shareUrl = `${process.env.NEXT_PUBLIC_FRONTEND_URL}/portfolio/share/${shareToken}`
       await navigator.clipboard.writeText(shareUrl)
       showToast('링크가 복사되었습니다!')
     } catch {


### PR DESCRIPTION
## 📌 개요

- **관련 이슈**: #59
- **작업 요약**: 공유 URL 수정 

---

## 🔍 주요 구현 내용

- 공유 URL 수정: 기존에 백엔드 shareUrl을 그대로 복사하던 방식에서 shareToken만 추출해 ${NEXT_PUBLIC_FRONTEND_URL}/portfolio/share/${shareToken} 형태의 프론트 URL로 변경
