### PR TITLE
feat: 마이페이지 편집/삭제 버튼 추가

### DIFF
--- a/src/app/home/my/page.tsx
+++ b/src/app/home/my/page.tsx
@@ -167,7 +167,7 @@ const MyPage = () => {
                     </div>
                     <div>
                       <h3 className="body-sb line-clamp-2 text-neutral-950">
-                        {portfolio.title}
+                        {portfolio.featuredProjectName ?? portfolio.title}
                       </h3>
                       <p className="body-m mt-2 line-clamp-3 whitespace-pre-line text-neutral-500">
                         {portfolio.summary || portfolio.description || '프로젝트 요약이 아직 없어요.'}

--- a/src/app/home/my/portfolios/[portfolioId]/page.tsx
+++ b/src/app/home/my/portfolios/[portfolioId]/page.tsx
@@ -1,16 +1,70 @@
 'use client'
 
-import { ArrowLeft } from 'lucide-react'
+import { useState } from 'react'
+import { ArrowLeft, Pencil, Trash2 } from 'lucide-react'
 import Link from 'next/link'
-import { useParams } from 'next/navigation'
+import { useParams, useRouter } from 'next/navigation'
 import { Button } from '@/components/ui/button'
 import PortfolioPreview from '@/features/portfolio/components/PortfolioPreview'
 import { usePortfolioDetail } from '@/hooks/usePortfolioDetail'
+import { useDeletePortfolio } from '@/hooks/usePortfolio'
+
+function DeleteModal({
+  title,
+  onConfirm,
+  onCancel,
+  loading,
+}: {
+  title: string
+  onConfirm: () => void
+  onCancel: () => void
+  loading: boolean
+}) {
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40">
+      <div className="bg-white rounded-2xl p-6 w-full max-w-sm mx-4">
+        <h3 className="body-sb text-neutral-950 mb-2">포트폴리오 삭제</h3>
+        <p className="body-m text-neutral-500 mb-6">
+          <span className="text-neutral-700">&ldquo;{title}&rdquo;</span>을(를) 삭제할까요?{' '}
+          삭제 후에는 복구할 수 없습니다.
+        </p>
+        <div className="flex gap-3 justify-end">
+          <button
+            onClick={onCancel}
+            disabled={loading}
+            className="body-m px-4 py-2 text-neutral-600 bg-neutral-100 rounded-xl hover:bg-neutral-200 transition disabled:opacity-50"
+          >
+            취소
+          </button>
+          <button
+            onClick={onConfirm}
+            disabled={loading}
+            className="body-m px-4 py-2 text-white bg-red-500 rounded-xl hover:bg-red-600 transition disabled:opacity-50"
+          >
+            {loading ? '삭제 중...' : '삭제'}
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}
 
 const PortfolioDetailPage = () => {
   const params = useParams<{ portfolioId: string }>()
   const portfolioId = params.portfolioId
+  const router = useRouter()
   const { portfolio, isLoading, error } = usePortfolioDetail(portfolioId)
+  const { remove, loading: deleting } = useDeletePortfolio()
+  const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false)
+
+  async function handleDelete() {
+    try {
+      await remove(Number(portfolioId))
+      router.push('/home/my')
+    } catch {
+      setIsDeleteModalOpen(false)
+    }
+  }
 
   if (isLoading) {
     return (
@@ -40,15 +94,43 @@ const PortfolioDetailPage = () => {
   return (
     <div className="flex w-full justify-center self-start px-6 py-10">
       <div className="flex w-full max-w-4xl flex-col gap-6 self-start">
-        <Button asChild variant="ghost" className="h-9 w-fit gap-2 rounded-lg px-2">
-          <Link href="/home/my">
-            <ArrowLeft size={16} />
-            목록으로
-          </Link>
-        </Button>
+        <div className="flex items-center justify-between">
+          <Button asChild variant="ghost" className="h-9 w-fit gap-2 rounded-lg px-2">
+            <Link href="/home/my">
+              <ArrowLeft size={16} />
+              목록으로
+            </Link>
+          </Button>
+
+          <div className="flex gap-2">
+            <Button asChild variant="outline" className="h-9 gap-2 rounded-lg px-3">
+              <Link href={`/portfolio/${portfolioId}/edit`}>
+                <Pencil size={16} />
+                편집
+              </Link>
+            </Button>
+            <Button
+              variant="outline"
+              className="h-9 gap-2 rounded-lg px-3 text-red-500 hover:bg-red-50"
+              onClick={() => setIsDeleteModalOpen(true)}
+            >
+              <Trash2 size={16} />
+              삭제
+            </Button>
+          </div>
+        </div>
 
         <PortfolioPreview portfolio={portfolio} />
       </div>
+
+      {isDeleteModalOpen && (
+        <DeleteModal
+          title={portfolio.title}
+          onConfirm={handleDelete}
+          onCancel={() => setIsDeleteModalOpen(false)}
+          loading={deleting}
+        />
+      )}
     </div>
   )
 }


### PR DESCRIPTION
## 📌 개요

- **관련 이슈**: #72
- **작업 요약**: 마이페이지 포트폴리오 카드 제목 수정 및 상세 페이지 편집/삭제 버튼 추가

---

## 🔍 주요 구현 내용

- **카드 제목 수정**: 마이페이지 포트폴리오 카드 제목을 portfolioTitle 대신 featuredProjectName으로 변경 (없으면 title 폴백)
- **편집 버튼 추가**: 상세 페이지 상단 "← 목록으로" 버튼과 같은 줄 오른쪽에 편집 버튼 추가, /portfolio/{portfolioId}/edit으로 이동
- **삭제 버튼 추가**: 확인 모달 후 삭제 API 호출, 완료 후 /home/my로 이동