### PR TITLE
[Feat] 마이 페이지 카드 수정

### DIFF
--- a/src/app/home/my/page.tsx
+++ b/src/app/home/my/page.tsx
@@ -1,12 +1,52 @@
 'use client'
 
-import { ArrowRight, FileText, FolderGit, Lock, Plus, UserRound } from 'lucide-react'
+import { ArrowRight, FileText, FolderGit, Lock, Plus, Trash2, UserRound } from 'lucide-react'
 import Link from 'next/link'
-import { useMemo } from 'react'
+import { useMemo, useState } from 'react'
 import { Button } from '@/components/ui/button'
-import { usePortfolios } from '@/hooks/usePortfolios'
+import { useDeletePortfolio } from '@/hooks/usePortfolio'
+import { type PortfolioSummary, usePortfolios } from '@/hooks/usePortfolios'
 import { useUserMe } from '@/hooks/useUserMe'
 import { formatKoreanDate } from '@/lib/date'
+
+function DeleteModal({
+  portfolio,
+  onConfirm,
+  onCancel,
+  loading,
+}: {
+  portfolio: PortfolioSummary
+  onConfirm: () => void
+  onCancel: () => void
+  loading: boolean
+}) {
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40">
+      <div className="mx-4 w-full max-w-sm rounded-2xl bg-white p-6">
+        <h3 className="body-sb mb-2 text-neutral-950">포트폴리오 삭제</h3>
+        <p className="body-m mb-6 text-neutral-500">
+          <span className="text-neutral-700">&ldquo;{portfolio.title}&rdquo;</span>을(를) 삭제할까요? 삭제 후에는 복구할 수 없습니다.
+        </p>
+        <div className="flex justify-end gap-3">
+          <button
+            onClick={onCancel}
+            disabled={loading}
+            className="body-m rounded-xl bg-neutral-100 px-4 py-2 text-neutral-600 transition hover:bg-neutral-200 disabled:opacity-50"
+          >
+            취소
+          </button>
+          <button
+            onClick={onConfirm}
+            disabled={loading}
+            className="body-m rounded-xl bg-red-500 px-4 py-2 text-white transition hover:bg-red-600 disabled:opacity-50"
+          >
+            {loading ? '삭제 중...' : '삭제'}
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}
 
 const MyPage = () => {
   const { user } = useUserMe()
@@ -18,7 +58,10 @@ const MyPage = () => {
     isLoading,
     error,
     setPage,
+    refetch,
   } = usePortfolios()
+  const { remove, loading: deleting } = useDeletePortfolio()
+  const [deleteTarget, setDeleteTarget] = useState<PortfolioSummary | null>(null)
 
   const latestUpdatedAt = useMemo(() => {
     const dates = portfolios
@@ -29,6 +72,18 @@ const MyPage = () => {
 
     return new Date(Math.max(...dates)).toISOString()
   }, [portfolios])
+
+  async function handleDelete() {
+    if (!deleteTarget) return
+
+    try {
+      await remove(Number(deleteTarget.portfolioId))
+      setDeleteTarget(null)
+      refetch()
+    } catch {
+      setDeleteTarget(null)
+    }
+  }
 
   return (
     <div className="flex w-full flex-col items-center self-start px-6 py-10">
@@ -141,12 +196,14 @@ const MyPage = () => {
           ) : (
             <div className="grid gap-3 md:grid-cols-2">
               {portfolios.map((portfolio) => (
-                <Link
+                <div
                   key={String(portfolio.portfolioId)}
-                  href={`/home/my/portfolios/${portfolio.portfolioId}`}
                   className="group flex min-h-44 flex-col justify-between rounded-lg border border-neutral-200 bg-white p-5 transition-all hover:border-neutral-400 hover:bg-neutral-50"
                 >
-                  <div className="flex flex-col gap-3">
+                  <Link
+                    href={`/home/my/portfolios/${portfolio.portfolioId}`}
+                    className="flex flex-col gap-3"
+                  >
                     <div className="flex items-center justify-between gap-3">
                       <span className="caption-m-sm text-neutral-400">
                         Template {portfolio.templateId}
@@ -173,18 +230,32 @@ const MyPage = () => {
                         {portfolio.summary || portfolio.description || '프로젝트 요약이 아직 없어요.'}
                       </p>
                     </div>
-                  </div>
+                  </Link>
 
                   <div className="mt-5 flex items-center justify-between gap-3">
                     <span className="caption-m-sm text-neutral-400">
                       {formatKoreanDate(portfolio.updatedAt)}
                     </span>
-                    <span className="inline-flex items-center gap-1 text-sm font-semibold text-neutral-700 transition-transform group-hover:translate-x-1">
-                      상세보기
-                      <ArrowRight size={15} />
-                    </span>
+                    <div className="flex items-center gap-2">
+                      <Button
+                        variant="outline"
+                        className="h-8 gap-1 rounded-lg border-red-100 px-2 text-red-500 hover:bg-red-50"
+                        onClick={() => setDeleteTarget(portfolio)}
+                        disabled={deleting}
+                      >
+                        <Trash2 size={14} />
+                        삭제
+                      </Button>
+                      <Link
+                        href={`/home/my/portfolios/${portfolio.portfolioId}`}
+                        className="inline-flex items-center gap-1 text-sm font-semibold text-neutral-700 transition-transform group-hover:translate-x-1"
+                      >
+                        상세보기
+                        <ArrowRight size={15} />
+                      </Link>
+                    </div>
                   </div>
-                </Link>
+                </div>
               ))}
             </div>
           )}
@@ -214,6 +285,15 @@ const MyPage = () => {
           )}
         </section>
       </div>
+
+      {deleteTarget && (
+        <DeleteModal
+          portfolio={deleteTarget}
+          onConfirm={handleDelete}
+          onCancel={() => setDeleteTarget(null)}
+          loading={deleting}
+        />
+      )}
     </div>
   )
 }

--- a/src/app/home/my/portfolios/[portfolioId]/page.tsx
+++ b/src/app/home/my/portfolios/[portfolioId]/page.tsx
@@ -1,68 +1,34 @@
 'use client'
 
 import { useState } from 'react'
-import { ArrowLeft, Pencil, Trash2 } from 'lucide-react'
+import { ArrowLeft, Pencil, Share2 } from 'lucide-react'
 import Link from 'next/link'
-import { useParams, useRouter } from 'next/navigation'
+import { useParams } from 'next/navigation'
 import { Button } from '@/components/ui/button'
 import PortfolioPreview from '@/features/portfolio/components/PortfolioPreview'
 import { usePortfolioDetail } from '@/hooks/usePortfolioDetail'
-import { useDeletePortfolio } from '@/hooks/usePortfolio'
-
-function DeleteModal({
-  title,
-  onConfirm,
-  onCancel,
-  loading,
-}: {
-  title: string
-  onConfirm: () => void
-  onCancel: () => void
-  loading: boolean
-}) {
-  return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40">
-      <div className="bg-white rounded-2xl p-6 w-full max-w-sm mx-4">
-        <h3 className="body-sb text-neutral-950 mb-2">포트폴리오 삭제</h3>
-        <p className="body-m text-neutral-500 mb-6">
-          <span className="text-neutral-700">&ldquo;{title}&rdquo;</span>을(를) 삭제할까요?{' '}
-          삭제 후에는 복구할 수 없습니다.
-        </p>
-        <div className="flex gap-3 justify-end">
-          <button
-            onClick={onCancel}
-            disabled={loading}
-            className="body-m px-4 py-2 text-neutral-600 bg-neutral-100 rounded-xl hover:bg-neutral-200 transition disabled:opacity-50"
-          >
-            취소
-          </button>
-          <button
-            onClick={onConfirm}
-            disabled={loading}
-            className="body-m px-4 py-2 text-white bg-red-500 rounded-xl hover:bg-red-600 transition disabled:opacity-50"
-          >
-            {loading ? '삭제 중...' : '삭제'}
-          </button>
-        </div>
-      </div>
-    </div>
-  )
-}
+import { createShareLink } from '@/lib/api/portfolio'
 
 const PortfolioDetailPage = () => {
   const params = useParams<{ portfolioId: string }>()
   const portfolioId = params.portfolioId
-  const router = useRouter()
   const { portfolio, isLoading, error } = usePortfolioDetail(portfolioId)
-  const { remove, loading: deleting } = useDeletePortfolio()
-  const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false)
+  const [toast, setToast] = useState<string | null>(null)
 
-  async function handleDelete() {
+  function showToast(message: string) {
+    setToast(message)
+    setTimeout(() => setToast(null), 3000)
+  }
+
+  async function handleShare() {
     try {
-      await remove(Number(portfolioId))
-      router.push('/home/my')
+      const { shareToken } = await createShareLink(Number(portfolioId))
+      const frontendUrl = process.env.NEXT_PUBLIC_FRONTEND_URL || window.location.origin
+      const shareUrl = `${frontendUrl}/portfolio/share/${shareToken}`
+      await navigator.clipboard.writeText(shareUrl)
+      showToast('링크가 복사되었습니다.')
     } catch {
-      setIsDeleteModalOpen(false)
+      showToast('링크 복사에 실패했습니다.')
     }
   }
 
@@ -93,6 +59,12 @@ const PortfolioDetailPage = () => {
 
   return (
     <div className="flex w-full justify-center self-start px-6 py-10">
+      {toast && (
+        <div className="body-m fixed top-6 left-1/2 z-50 -translate-x-1/2 rounded-xl bg-neutral-900 px-6 py-3 text-white shadow-lg">
+          {toast}
+        </div>
+      )}
+
       <div className="flex w-full max-w-4xl flex-col gap-6 self-start">
         <div className="flex items-center justify-between">
           <Button asChild variant="ghost" className="h-9 w-fit gap-2 rounded-lg px-2">
@@ -103,34 +75,26 @@ const PortfolioDetailPage = () => {
           </Button>
 
           <div className="flex gap-2">
+            <Button
+              variant="outline"
+              className="h-9 gap-2 rounded-lg px-3"
+              onClick={handleShare}
+              disabled={!portfolio.isPublic}
+            >
+              <Share2 size={16} />
+              공유
+            </Button>
             <Button asChild variant="outline" className="h-9 gap-2 rounded-lg px-3">
               <Link href={`/portfolio/${portfolioId}/edit`}>
                 <Pencil size={16} />
                 편집
               </Link>
             </Button>
-            <Button
-              variant="outline"
-              className="h-9 gap-2 rounded-lg px-3 text-red-500 hover:bg-red-50"
-              onClick={() => setIsDeleteModalOpen(true)}
-            >
-              <Trash2 size={16} />
-              삭제
-            </Button>
           </div>
         </div>
 
         <PortfolioPreview portfolio={portfolio} />
       </div>
-
-      {isDeleteModalOpen && (
-        <DeleteModal
-          title={portfolio.title}
-          onConfirm={handleDelete}
-          onCancel={() => setIsDeleteModalOpen(false)}
-          loading={deleting}
-        />
-      )}
     </div>
   )
 }

--- a/src/app/portfolio/page.tsx
+++ b/src/app/portfolio/page.tsx
@@ -1,5 +1,5 @@
-import PortfolioListPage from '@/features/portfolio/components/PortfolioListPage'
+import { redirect } from 'next/navigation'
 
 export default function Page() {
-  return <PortfolioListPage />
+  redirect('/home/my')
 }

--- a/src/hooks/usePortfolios.ts
+++ b/src/hooks/usePortfolios.ts
@@ -1,6 +1,6 @@
 'use client'
 
-import { useEffect, useState } from 'react'
+import { useCallback, useEffect, useState } from 'react'
 import axios from 'axios'
 import axiosInstance from '@/lib/api/axios'
 
@@ -69,6 +69,36 @@ export const usePortfolios = () => {
     fetchPortfolios()
   }, [page])
 
+  const refetch = useCallback(async () => {
+    setIsLoading(true)
+    setError(null)
+
+    try {
+      const { data } = await axiosInstance.get<PortfolioListResponse>('/api/portfolio', {
+        params: {
+          page,
+          perPage: 6,
+          sort: 'createdAt',
+          direction: 'desc',
+        },
+      })
+
+      setPortfolios(data.data.content)
+      setTotalPages(data.data.totalPages)
+      setTotalElements(data.data.totalElements)
+    } catch (err) {
+      if (axios.isAxiosError(err)) {
+        const status = err.response?.status
+        if (status === 400) setError('인증이 만료되었어요. 다시 로그인해 주세요.')
+        else setError('포트폴리오 목록을 불러오지 못했어요.')
+      } else {
+        setError('알 수 없는 오류가 발생했어요.')
+      }
+    } finally {
+      setIsLoading(false)
+    }
+  }, [page])
+
   return {
     portfolios,
     page,
@@ -77,5 +107,6 @@ export const usePortfolios = () => {
     isLoading,
     error,
     setPage,
+    refetch,
   }
 }


### PR DESCRIPTION
## 📌 개요

- **관련 이슈**: Close #74 
- **작업 요약**: 포트폴리오 액션 위치를 사용 흐름에 맞게 재배치했습니다.

## ✅ 작업 내용

- `/portfolio` 목록 페이지를 `/home/my`로 리다이렉트하도록 변경
- 마이페이지 포트폴리오 카드에 삭제 액션 추가
- 삭제 시 기존 삭제 확인 모달 및 삭제 API 흐름 유지
- 삭제 후 마이페이지 포트폴리오 목록이 갱신되도록 `refetch` 추가
- 포트폴리오 상세 페이지에서 삭제 액션 제거
- 포트폴리오 상세 페이지 상단에 공유/편집 액션 배치
- 공유 시 기존 공유 링크 생성 및 클립보드 복사 흐름 유지