### PR TITLE
[Feat] 분석 결과에 PR 리뷰 수 표시

### DIFF
--- a/src/app/home/repos/analyze/page.tsx
+++ b/src/app/home/repos/analyze/page.tsx
@@ -22,6 +22,7 @@ const AnalyzePage = () => {
   }
 
   const { aiInputData } = analyzeResult
+  const prReviewCount = analyzeResult.prReviewCount ?? aiInputData.prReviewCount ?? 0
 
   return (
     <div className="flex w-full flex-col items-center gap-10 px-6 py-12">
@@ -42,7 +43,7 @@ const AnalyzePage = () => {
         </div>
 
         {/* 스탯 */}
-        <div className="grid grid-cols-3 gap-3">
+        <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
           <div className="flex flex-col gap-1 rounded-2xl border border-neutral-200 p-5">
             <span className="caption-m-sm text-neutral-400">커밋 수</span>
             <span className="title-bold text-neutral-950">{analyzeResult.commitCount.toLocaleString()}</span>
@@ -50,6 +51,10 @@ const AnalyzePage = () => {
           <div className="flex flex-col gap-1 rounded-2xl border border-neutral-200 p-5">
             <span className="caption-m-sm text-neutral-400">스타</span>
             <span className="title-bold text-neutral-950">{analyzeResult.starCount.toLocaleString()}</span>
+          </div>
+          <div className="flex flex-col gap-1 rounded-2xl border border-neutral-200 p-5">
+            <span className="caption-m-sm text-neutral-400">PR 리뷰</span>
+            <span className="title-bold text-neutral-950">{prReviewCount.toLocaleString()}</span>
           </div>
           <div className="flex flex-col gap-1 rounded-2xl border border-neutral-200 p-5">
             <span className="caption-m-sm text-neutral-400">중요도 점수</span>

--- a/src/store/repoStore.ts
+++ b/src/store/repoStore.ts
@@ -24,6 +24,7 @@ export interface AnalyzeResult {
   activitySummary: string
   starCount: number
   commitCount: number
+  prReviewCount: number
   importanceScore: number
   aiInputData: {
     projectName: string
@@ -39,6 +40,7 @@ export interface AnalyzeResult {
     forkCount: number
     openIssuesCount: number
     commitCount: number
+    prReviewCount: number
     importanceScore: number
     repositoryCreatedAt: string
     repositoryUpdatedAt: string


### PR DESCRIPTION
## 📌 개요

- **관련 이슈**: Closes #76 
- **작업 요약**: 레포지토리 분석 결과 화면에서 PR 리뷰 수를 확인할 수 있도록 추가했습니다.

## ✅ 작업 내용

- 레포지토리 분석 결과 타입에 `prReviewCount` 추가
- 분석 결과 스탯 영역에 `PR 리뷰` 카드 추가
- `analyzeResult.prReviewCount` 값을 우선 표시
- 루트 값이 없을 경우 `aiInputData.prReviewCount`를 fallback으로 사용
- 기존 커밋 수, 스타 수, 중요도 점수 표시 유지