### PR TITLE
fix: PDF 내보내기 시 발생하는 색상 파싱 에러 해결

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
         "axios": "^1.16.1",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
-        "html2canvas": "^1.4.1",
+        "html2canvas-pro": "^2.0.4",
         "jspdf": "^2.5.1",
         "lucide-react": "^1.8.0",
         "next": "16.2.3",
@@ -7276,12 +7276,26 @@
       "resolved": "https://registry.npmjs.org/html2canvas/-/html2canvas-1.4.1.tgz",
       "integrity": "sha512-fPU6BHNpsyIhr8yyMpTLLxAbkaK8ArIBcmZIRiBLiDhjeqvXolaEmDGmELFuX9I4xDcaKKcJl+TKZLqruBbmWA==",
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "css-line-break": "^2.1.0",
         "text-segmentation": "^1.0.3"
       },
       "engines": {
         "node": ">=8.0.0"
+      }
+    },
+    "node_modules/html2canvas-pro": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/html2canvas-pro/-/html2canvas-pro-2.0.4.tgz",
+      "integrity": "sha512-tfL8XNvuITvYQJKgAx4bvANauuLKc88C+ZSZt7HZJveqQBWjBDtkqs/It06UzlqbM+sSq7Cv45rFbuUxOFgmow==",
+      "license": "MIT",
+      "dependencies": {
+        "css-line-break": "^2.1.0",
+        "text-segmentation": "^1.0.3"
+      },
+      "engines": {
+        "node": ">=16.0.0"
       }
     },
     "node_modules/http-errors": {

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "axios": "^1.16.1",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
-    "html2canvas": "^1.4.1",
+    "html2canvas-pro": "^2.0.4",
     "jspdf": "^2.5.1",
     "lucide-react": "^1.8.0",
     "next": "16.2.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,9 +17,9 @@ importers:
       clsx:
         specifier: ^2.1.1
         version: 2.1.1
-      html2canvas:
-        specifier: ^1.4.1
-        version: 1.4.1
+      html2canvas-pro:
+        specifier: ^2.0.4
+        version: 2.0.4
       jspdf:
         specifier: ^2.5.1
         version: 2.5.2
@@ -2508,6 +2508,10 @@ packages:
   hono@4.12.12:
     resolution: {integrity: sha512-p1JfQMKaceuCbpJKAPKVqyqviZdS0eUxH9v82oWo1kb9xjQ5wA6iP3FNVAPDFlz5/p7d45lO+BpSk1tuSZMF4Q==}
     engines: {node: '>=16.9.0'}
+
+  html2canvas-pro@2.0.4:
+    resolution: {integrity: sha512-tfL8XNvuITvYQJKgAx4bvANauuLKc88C+ZSZt7HZJveqQBWjBDtkqs/It06UzlqbM+sSq7Cv45rFbuUxOFgmow==}
+    engines: {node: '>=16.0.0'}
 
   html2canvas@1.4.1:
     resolution: {integrity: sha512-fPU6BHNpsyIhr8yyMpTLLxAbkaK8ArIBcmZIRiBLiDhjeqvXolaEmDGmELFuX9I4xDcaKKcJl+TKZLqruBbmWA==}
@@ -6545,10 +6549,16 @@ snapshots:
 
   hono@4.12.12: {}
 
+  html2canvas-pro@2.0.4:
+    dependencies:
+      css-line-break: 2.1.0
+      text-segmentation: 1.0.3
+
   html2canvas@1.4.1:
     dependencies:
       css-line-break: 2.1.0
       text-segmentation: 1.0.3
+    optional: true
 
   http-errors@2.0.1:
     dependencies:

--- a/src/app/home/my/portfolios/[portfolioId]/page.tsx
+++ b/src/app/home/my/portfolios/[portfolioId]/page.tsx
@@ -40,7 +40,7 @@ const PortfolioDetailPage = () => {
     setIsExporting(true)
     try {
       const [{ default: html2canvas }, { default: jsPDF }] = await Promise.all([
-        import('html2canvas'),
+        import('html2canvas-pro'),
         import('jspdf'),
       ])
 


### PR DESCRIPTION
## 📌 개요
- **관련 이슈**: #68
- **작업 요약**: PDF 내보내기 시 발생하는 색상 파싱 에러 수정

---
## 🔍 주요 구현 내용

### 1. 기능 설명
- **html2canvas-pro로 교체**: Tailwind v4의 `oklch`/`lab` 색상 함수를 파싱하지 못해 발생한 "Attempting to parse an unsupported color function lab" 에러 해결

### 2. 핵심 코드/로직
- `html2canvas` → `html2canvas-pro`로 패키지 교체 (API 동일, import 경로만 변경)
- `pnpm-lock.yaml` 동기화

---
## 🤔 고민한 점 및 해결 과정
- **Issue**: PDF 내보내기 버튼 클릭 시 콘솔에 `lab` 색상 파싱 에러 발생, PDF 생성 안 됨
- **Decision**: `html2canvas-pro`로 교체
- **Reason**: Tailwind v4가 사용하는 oklch/lab 색상 포맷을 기존 `html2canvas`는 지원하지 않음. `html2canvas-pro`는 해당 색상 함수를 지원하는 포크 버전