### PR TITLE
feat: PDF 내보내기 레이아웃 및 링크 표시 개선

### DIFF
--- a/src/app/home/my/portfolios/[portfolioId]/page.tsx
+++ b/src/app/home/my/portfolios/[portfolioId]/page.tsx
@@ -44,11 +44,20 @@ const PortfolioDetailPage = () => {
         import('jspdf'),
       ])
 
-      const canvas = await html2canvas(previewRef.current, {
-        scale: 2,
-        useCORS: true,
-        backgroundColor: '#ffffff',
-      })
+      const element = previewRef.current
+      const originalPadding = element.style.padding
+      element.style.padding = '0 32px'
+
+      let canvas
+      try {
+        canvas = await html2canvas(element, {
+          scale: 2,
+          useCORS: true,
+          backgroundColor: '#ffffff',
+        })
+      } finally {
+        element.style.padding = originalPadding
+      }
 
       const imgData = canvas.toDataURL('image/png')
       const pdf = new jsPDF('p', 'mm', 'a4')

--- a/src/app/home/my/portfolios/[portfolioId]/page.tsx
+++ b/src/app/home/my/portfolios/[portfolioId]/page.tsx
@@ -35,7 +35,7 @@ const PortfolioDetailPage = () => {
   }
 
   const handleExportPdf = async () => {
-    if (!previewRef.current) return
+    if (!previewRef.current || !portfolio) return
 
     setIsExporting(true)
     try {
@@ -48,6 +48,45 @@ const PortfolioDetailPage = () => {
       const originalPadding = element.style.padding
       element.style.padding = '0 32px'
 
+      const hiddenElements: HTMLElement[] = []
+      const addedElements: HTMLElement[] = []
+      const articles = element.querySelectorAll<HTMLElement>('article')
+
+      portfolio.projects.forEach((project, index) => {
+        const article = articles[index]
+        if (!article) return
+
+        const linkButtons = article.querySelector<HTMLElement>('[data-pdf-hide]')
+        if (linkButtons) {
+          linkButtons.style.display = 'none'
+          hiddenElements.push(linkButtons)
+        }
+
+        if (project.githubUrl || project.deployUrl) {
+          const linksEl = document.createElement('div')
+          linksEl.style.marginTop = '12px'
+          linksEl.style.display = 'flex'
+          linksEl.style.flexDirection = 'column'
+          linksEl.style.gap = '4px'
+          linksEl.style.fontSize = '13px'
+          linksEl.style.color = '#737373'
+
+          if (project.githubUrl) {
+            const p = document.createElement('p')
+            p.textContent = `GitHub: ${project.githubUrl}`
+            linksEl.appendChild(p)
+          }
+          if (project.deployUrl) {
+            const p = document.createElement('p')
+            p.textContent = `배포: ${project.deployUrl}`
+            linksEl.appendChild(p)
+          }
+
+          article.appendChild(linksEl)
+          addedElements.push(linksEl)
+        }
+      })
+
       let canvas
       try {
         canvas = await html2canvas(element, {
@@ -57,6 +96,10 @@ const PortfolioDetailPage = () => {
         })
       } finally {
         element.style.padding = originalPadding
+        hiddenElements.forEach((el) => {
+          el.style.display = ''
+        })
+        addedElements.forEach((el) => el.remove())
       }
 
       const imgData = canvas.toDataURL('image/png')

--- a/src/features/portfolio/components/PortfolioPreview.tsx
+++ b/src/features/portfolio/components/PortfolioPreview.tsx
@@ -121,7 +121,7 @@ export default function PortfolioPreview({ portfolio, eyebrow }: PortfolioPrevie
                     )}
                   </div>
                   {(project.githubUrl || project.deployUrl) && (
-                    <div className="flex flex-wrap gap-2">
+                    <div className="flex flex-wrap gap-2" data-pdf-hide="true">
                       {project.githubUrl && (
                         <Button asChild variant="outline" className="h-9 w-fit gap-2 rounded-lg px-3">
                           <a href={project.githubUrl} target="_blank" rel="noopener noreferrer">


### PR DESCRIPTION
## 📌 개요
- **관련 이슈**: #68
- **작업 요약**: PDF 내보내기 색상 파싱 에러 수정 및 레이아웃/링크 표시 개선

---
## 🔍 주요 구현 내용

- **좌우 패딩 추가**: PDF 캡처 시점에 `previewRef`에 좌우 32px 패딩 임시 적용, 캡처 후 복원
- **GitHub/배포 링크 텍스트 표시**: PDF 캡처 시 GitHub/배포 버튼을 숨기고, 카드 하단에 "GitHub: URL", "배포: URL" 텍스트로 추가 (배포는 `deployUrl` 있을 때만)