### PR TITLE
[Feat] 홈 페이지 UI 수정

### DIFF
--- a/src/app/home/page.tsx
+++ b/src/app/home/page.tsx
@@ -1,69 +1,103 @@
 'use client'
 
-import FeatureCard from '@/features/home/components/FeatureCard'
+import { ArrowRight, CheckCircle2, FileText, GitBranch, Sparkles } from 'lucide-react'
 import { Button } from '@/components/ui/button'
+import FeatureCard from '@/features/home/components/FeatureCard'
 import { useGithubRepos } from '@/hooks/useGithubRepos'
 
 const HomePage = () => {
   const { isLoading, error, fetchRepos } = useGithubRepos()
 
   return (
-    <div className="flex w-full flex-col gap-20 px-6 py-12">
-      {/* Hero Section */}
-      <section className="flex flex-col items-center justify-center gap-5">
-        <div className="flex w-fit items-center gap-2 rounded-full border border-neutral-200 bg-neutral-50 px-4 py-2">
-          <div className="h-2 w-2 rounded-full bg-emerald-500" />
-          <span className="caption-m-sm text-neutral-500">
-            개발 스토리를 포트폴리오로
-          </span>
-        </div>
-        <div className="flex flex-col items-center gap-6 text-center">
-          <h1 className="title-bold text-neutral-950">
-            나만의 개발 스토리를 담는
-            <br />
-            포트폴리오 서비스
-          </h1>
-          <p className="body-m break-keep leading-relaxed text-neutral-400">
-            GitHub 활동과 프로젝트 경험을 연결해
-            <br />
-            나만의 개발 여정을 한눈에 정리해보세요.
-          </p>
-        </div>
-      </section>
-      {/* Cards */}
-      <section>
-        <div className="grid grid-cols-3 gap-6">
+    <div className="flex w-full flex-col items-center px-6 py-12">
+      <div className="flex w-full max-w-6xl flex-col gap-12">
+        <section className="grid items-center gap-10 lg:grid-cols-[1.05fr_0.95fr]">
+          <div className="flex flex-col gap-7">
+            <div className="flex w-fit items-center gap-2 rounded-full border border-blue-100 bg-blue-50 px-4 py-2 text-blue-600">
+              <Sparkles size={16} />
+              <span className="caption-m-sm">기업 제출용 포트폴리오 준비</span>
+            </div>
+
+            <div className="flex flex-col gap-5">
+              <h1 className="text-5xl font-bold leading-tight text-neutral-950">
+                GitHub 기록을
+                <br />
+                제출 가능한 포트폴리오로
+              </h1>
+              <p className="body-m max-w-xl break-keep leading-relaxed text-neutral-500">
+                프로젝트 경험, 기술 스택, 핵심 기여를 한 번에 정리해
+                이력서와 기업 제출에 바로 활용할 수 있는 포트폴리오를 만들어보세요.
+              </p>
+            </div>
+
+            <div className="flex flex-col gap-3 sm:flex-row sm:items-center">
+              <Button
+                variant="secondary"
+                className="body-sb h-14 w-full gap-2 rounded-lg bg-neutral-950 px-6 text-white hover:bg-neutral-800 disabled:opacity-50 sm:w-fit"
+                onClick={fetchRepos}
+                disabled={isLoading}
+              >
+                <GitBranch size={20} />
+                {isLoading ? '불러오는 중...' : 'GitHub에서 레포지토리 불러오기'}
+                {!isLoading && <ArrowRight size={18} />}
+              </Button>
+              <p className="caption-m-sm text-neutral-400">
+                {error ?? '레포지토리 선택 후 포트폴리오 초안을 생성할 수 있어요.'}
+              </p>
+            </div>
+          </div>
+
+          <div className="rounded-lg border border-neutral-200 bg-white p-5 shadow-sm">
+            <div className="flex items-center justify-between border-b border-neutral-100 pb-4">
+              <div>
+                <p className="caption-m-sm text-neutral-400">Portfolio Draft</p>
+                <h2 className="body-sb mt-1 text-neutral-950">제출 자료 구성</h2>
+              </div>
+              <div className="flex h-10 w-10 items-center justify-center rounded-lg bg-blue-500 text-white">
+                <FileText size={20} />
+              </div>
+            </div>
+
+            <div className="mt-5 flex flex-col gap-3">
+              {[
+                '프로젝트 한 줄 소개',
+                '담당 역할과 핵심 기여',
+                '사용 기술 스택',
+                'GitHub 및 배포 링크',
+              ].map((item) => (
+                <div
+                  key={item}
+                  className="flex items-center gap-3 rounded-lg bg-neutral-50 px-4 py-3"
+                >
+                  <CheckCircle2 size={18} className="text-blue-500" />
+                  <span className="body-m text-neutral-700">{item}</span>
+                </div>
+              ))}
+            </div>
+          </div>
+        </section>
+
+        <section className="grid gap-4 md:grid-cols-3">
           <FeatureCard
-            label="PROJECT ARCHIVE"
-            title={'프로젝트를\n보기 좋게 정리'}
+            label="PROJECT SUMMARY"
+            title={'프로젝트 경험을\n읽기 쉽게 정리'}
+            description="레포지토리 설명과 활동 기록을 바탕으로 제출용 프로젝트 내용을 정돈합니다."
             theme="dark"
           />
           <FeatureCard
             label="GITHUB SYNC"
             title={'GitHub 기록을\n자동으로 연결'}
+            description="커밋, README, 기술 정보를 불러와 포트폴리오 초안에 반영합니다."
             theme="light"
           />
           <FeatureCard
-            label="TECH STACK"
-            title={'기술 스택과\n성장 흐름 시각화'}
+            label="TECH CONTRIBUTION"
+            title={'기술 스택과\n핵심 기여 정리'}
+            description="시각화 대신 기업이 확인하기 좋은 역할, 기여, 기술 근거를 보여줍니다."
             theme="blue"
           />
-        </div>
-      </section>
-      {/* CTA */}
-      <section className="flex flex-col items-center gap-3">
-        <Button
-          variant="secondary"
-          className="body-sb h-auto rounded-2xl bg-neutral-900 px-10 py-5 text-white hover:bg-neutral-800 disabled:opacity-50"
-          onClick={fetchRepos}
-          disabled={isLoading}
-        >
-          {isLoading ? '불러오는 중...' : 'Github에서 레포지토리 불러오기'}
-        </Button>
-        <p className="caption-m-sm text-neutral-400">
-          {error ?? '몇 분 안에 나만의 포트폴리오를 시작해보세요.'}
-        </p>
-      </section>
+        </section>
+      </div>
     </div>
   )
 }

--- a/src/features/home/components/FeatureCard.tsx
+++ b/src/features/home/components/FeatureCard.tsx
@@ -1,33 +1,51 @@
 interface FeatureCardProps {
   label: string
   title: string
+  description: string
   theme: 'dark' | 'light' | 'blue'
 }
 
 const themeClass = {
-  dark: 'bg-neutral-900 text-white',
-  light: 'bg-neutral-100 text-black',
-  blue: 'bg-[#E8F1FF] text-black',
+  dark: 'border-neutral-900 bg-neutral-950 text-white',
+  light: 'border-neutral-200 bg-white text-neutral-950',
+  blue: 'border-blue-100 bg-blue-50 text-neutral-950',
+}
+
+const labelClass = {
+  dark: 'text-neutral-400',
+  light: 'text-neutral-400',
+  blue: 'text-blue-500',
+}
+
+const descriptionClass = {
+  dark: 'text-neutral-300',
+  light: 'text-neutral-500',
+  blue: 'text-neutral-600',
 }
 
 export default function FeatureCard({
   label,
   title,
+  description,
   theme,
 }: FeatureCardProps) {
   return (
     <article
-      className={`flex flex-col justify-between rounded-[36px] p-8 ${themeClass[theme]}`}
+      className={`flex min-h-44 flex-col justify-between rounded-lg border p-6 ${themeClass[theme]}`}
     >
       <div>
-        <p className="caption-m-lg opacity-60">
+        <p className={`caption-m-sm ${labelClass[theme]}`}>
           {label}
         </p>
 
-        <h2 className="title-bold mt-6 whitespace-pre-line">
+        <h2 className="title-sb-md mt-4 whitespace-pre-line">
           {title}
         </h2>
       </div>
+
+      <p className={`body-m mt-5 break-keep ${descriptionClass[theme]}`}>
+        {description}
+      </p>
     </article>
   )
 }


### PR DESCRIPTION
## 📌 개요

- **관련 이슈**: Closes #79 
- **작업 요약**: 홈 페이지를 기업 제출용 포트폴리오 생성 목적에 맞게 리뉴얼했습니다.

## ✅ 작업 내용

- 홈 히어로 문구를 기업 제출용 포트폴리오 맥락에 맞게 변경
- 기존 “성장 흐름 시각화” 메시지 제거
- 제출 자료 구성 패널 추가
- CTA 영역을 히어로 안으로 이동해 레포지토리 불러오기 흐름 강조
- 기능 카드 문구를 프로젝트 요약, GitHub 연동, 핵심 기여 정리 중심으로 변경
- `FeatureCard`에 설명 문구를 추가해 카드 정보량 보강
- 카드 디자인을 더 정돈된 제출/문서 톤으로 개선