### PR TITLE
feat: PDF 내보내기 3차 수정

### DIFF
--- a/src/app/home/my/portfolios/[portfolioId]/page.tsx
+++ b/src/app/home/my/portfolios/[portfolioId]/page.tsx
@@ -60,35 +60,51 @@ const PortfolioDetailPage = () => {
         const article = articles[index]
         if (!article) return
 
-        if (project.githubUrl || project.deployUrl) {
+        if (project.githubUrl) {
           const section = document.createElement('div')
           section.className = 'border-t border-neutral-100 pt-4'
+          section.setAttribute('data-pdf-section', 'true')
 
           const caption = document.createElement('span')
           caption.className = 'caption-m-sm text-neutral-400'
-          caption.textContent = '관련 링크'
+          caption.textContent = 'GitHub 링크'
           section.appendChild(caption)
 
-          const linksEl = document.createElement('div')
-          linksEl.className = 'mt-2 flex flex-col gap-1'
+          const link = document.createElement('p')
+          link.className = 'body-m mt-2 text-neutral-700'
+          link.textContent = project.githubUrl
+          section.appendChild(link)
 
-          if (project.githubUrl) {
-            const p = document.createElement('p')
-            p.className = 'body-sb text-neutral-950'
-            p.textContent = `GitHub: ${project.githubUrl}`
-            linksEl.appendChild(p)
-          }
-          if (project.deployUrl) {
-            const p = document.createElement('p')
-            p.className = 'body-sb text-neutral-950'
-            p.textContent = `배포: ${project.deployUrl}`
-            linksEl.appendChild(p)
-          }
-
-          section.appendChild(linksEl)
           article.appendChild(section)
           addedElements.push(section)
         }
+
+        if (project.deployUrl) {
+          const section = document.createElement('div')
+          section.className = 'border-t border-neutral-100 pt-4'
+          section.setAttribute('data-pdf-section', 'true')
+
+          const caption = document.createElement('span')
+          caption.className = 'caption-m-sm text-neutral-400'
+          caption.textContent = '배포 링크'
+          section.appendChild(caption)
+
+          const link = document.createElement('p')
+          link.className = 'body-m mt-2 text-neutral-700'
+          link.textContent = project.deployUrl
+          section.appendChild(link)
+
+          article.appendChild(section)
+          addedElements.push(section)
+        }
+      })
+
+      const elementRect = element.getBoundingClientRect()
+      const sectionRects = Array.from(
+        element.querySelectorAll<HTMLElement>('[data-pdf-section]'),
+      ).map((el) => {
+        const rect = el.getBoundingClientRect()
+        return { top: rect.top - elementRect.top, bottom: rect.bottom - elementRect.top }
       })
 
       let canvas
@@ -106,24 +122,52 @@ const PortfolioDetailPage = () => {
         addedElements.forEach((el) => el.remove())
       }
 
-      const imgData = canvas.toDataURL('image/png')
       const pdf = new jsPDF('p', 'mm', 'a4')
       const pdfWidth = pdf.internal.pageSize.getWidth()
       const pdfHeight = pdf.internal.pageSize.getHeight()
-      const imgHeight = (canvas.height * pdfWidth) / canvas.width
 
-      let heightLeft = imgHeight
-      let position = 0
+      const pxScale = canvas.width / elementRect.width
+      const sections = sectionRects
+        .map((s) => ({ top: s.top * pxScale, bottom: s.bottom * pxScale }))
+        .sort((a, b) => a.top - b.top)
 
-      pdf.addImage(imgData, 'PNG', 0, position, pdfWidth, imgHeight)
-      heightLeft -= pdfHeight
+      const pageHeightPx = (pdfHeight * canvas.width) / pdfWidth
 
-      while (heightLeft > 0) {
-        position -= pdfHeight
-        pdf.addPage()
-        pdf.addImage(imgData, 'PNG', 0, position, pdfWidth, imgHeight)
-        heightLeft -= pdfHeight
+      const pageRanges: { start: number; end: number }[] = []
+      let cursor = 0
+      while (cursor < canvas.height) {
+        let pageEnd = Math.min(cursor + pageHeightPx, canvas.height)
+
+        if (pageEnd < canvas.height) {
+          const crossing = sections.filter(
+            (s) => s.top > cursor && s.top < pageEnd && s.bottom > pageEnd,
+          )
+          if (crossing.length > 0) {
+            pageEnd = Math.min(...crossing.map((s) => s.top))
+          }
+        }
+
+        pageRanges.push({ start: cursor, end: pageEnd })
+        cursor = pageEnd
       }
+
+      pageRanges.forEach(({ start, end }, index) => {
+        const sliceHeight = end - start
+        if (sliceHeight <= 0) return
+
+        const pageCanvas = document.createElement('canvas')
+        pageCanvas.width = canvas.width
+        pageCanvas.height = sliceHeight
+
+        const ctx = pageCanvas.getContext('2d')
+        ctx?.drawImage(canvas, 0, start, canvas.width, sliceHeight, 0, 0, canvas.width, sliceHeight)
+
+        const sliceImgData = pageCanvas.toDataURL('image/png')
+        const sliceHeightMm = (sliceHeight * pdfWidth) / canvas.width
+
+        if (index > 0) pdf.addPage()
+        pdf.addImage(sliceImgData, 'PNG', 0, 0, pdfWidth, sliceHeightMm)
+      })
 
       pdf.save(`${portfolio?.title || 'portfolio'}.pdf`)
     } finally {

--- a/src/features/portfolio/components/PortfolioPreview.tsx
+++ b/src/features/portfolio/components/PortfolioPreview.tsx
@@ -45,7 +45,10 @@ interface PortfolioPreviewProps {
 export default function PortfolioPreview({ portfolio, eyebrow }: PortfolioPreviewProps) {
   return (
     <div className="flex w-full flex-col gap-6">
-      <section className="overflow-hidden rounded-lg border border-neutral-200 bg-white">
+      <section
+        className="overflow-hidden rounded-lg border border-neutral-200 bg-white"
+        data-pdf-section="true"
+      >
         <div className="h-1.5 bg-neutral-950" />
         <div className="flex flex-col gap-6">
           <div className="flex flex-col gap-5 p-6 sm:flex-row sm:items-start sm:justify-between">
@@ -90,7 +93,10 @@ export default function PortfolioPreview({ portfolio, eyebrow }: PortfolioPrevie
       </section>
 
       {portfolio.description && (
-        <section className="rounded-lg border border-neutral-200 bg-white p-5">
+        <section
+          className="rounded-lg border border-neutral-200 bg-white p-5"
+          data-pdf-section="true"
+        >
           <span className="caption-m-sm text-neutral-400">설명</span>
           <p className="body-m mt-3 whitespace-pre-line break-keep leading-relaxed text-neutral-700">
             {portfolio.description}
@@ -99,7 +105,7 @@ export default function PortfolioPreview({ portfolio, eyebrow }: PortfolioPrevie
       )}
 
       <section className="flex flex-col gap-3">
-        <div>
+        <div data-pdf-section="true">
           <span className="caption-m-sm text-neutral-400">Projects</span>
           <h2 className="title-sb-md mt-1 text-neutral-950">프로젝트 구성</h2>
         </div>
@@ -111,7 +117,10 @@ export default function PortfolioPreview({ portfolio, eyebrow }: PortfolioPrevie
               className="rounded-lg border border-neutral-200 bg-white p-5"
             >
               <div className="flex flex-col gap-4">
-                <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+                <div
+                  className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between"
+                  data-pdf-section="true"
+                >
                   <div>
                     <span className="inline-flex w-fit rounded-full bg-neutral-100 px-2.5 py-1 text-xs font-semibold text-neutral-500">
                       Project {project.order ?? index + 1}
@@ -148,7 +157,10 @@ export default function PortfolioPreview({ portfolio, eyebrow }: PortfolioPrevie
                 </div>
 
                 {(project.estimatedPeriod || project.role) && (
-                  <div className="grid gap-3 sm:grid-cols-2">
+                  <div
+                    className="grid gap-3 sm:grid-cols-2"
+                    data-pdf-section="true"
+                  >
                     {project.estimatedPeriod && (
                       <div className="rounded-lg bg-neutral-50 p-4">
                         <span className="caption-m-sm text-neutral-400">개발 기간</span>
@@ -165,13 +177,16 @@ export default function PortfolioPreview({ portfolio, eyebrow }: PortfolioPrevie
                 )}
 
                 {project.description && (
-                  <p className="body-m whitespace-pre-line break-keep border-l-2 border-neutral-200 pl-4 leading-relaxed text-neutral-600">
+                  <p
+                    className="body-m whitespace-pre-line break-keep border-l-2 border-neutral-200 pl-4 leading-relaxed text-neutral-600"
+                    data-pdf-section="true"
+                  >
                     {project.description}
                   </p>
                 )}
 
                 {(project.techStacks?.length ?? 0) > 0 && (
-                  <div>
+                  <div data-pdf-section="true">
                     <span className="caption-m-sm text-neutral-400">기술 스택</span>
                     <div className="mt-2 flex flex-wrap gap-2">
                       {project.techStacks?.map((stack) => (
@@ -187,7 +202,10 @@ export default function PortfolioPreview({ portfolio, eyebrow }: PortfolioPrevie
                 )}
 
                 {(project.mainFeatures?.length ?? 0) > 0 && (
-                  <div className="border-t border-neutral-100 pt-4">
+                  <div
+                    className="border-t border-neutral-100 pt-4"
+                    data-pdf-section="true"
+                  >
                     <span className="caption-m-sm text-neutral-400">주요 기능</span>
                     <ul className="mt-2 flex flex-col gap-2">
                       {project.mainFeatures?.map((feature) => (
@@ -206,7 +224,10 @@ export default function PortfolioPreview({ portfolio, eyebrow }: PortfolioPrevie
       </section>
 
       {(portfolio.technicalContributions?.length ?? 0) > 0 && (
-        <section className="rounded-lg border border-neutral-200 bg-white p-6">
+        <section
+          className="rounded-lg border border-neutral-200 bg-white p-6"
+          data-pdf-section="true"
+        >
           <span className="caption-m-sm text-neutral-400">기술적 기여</span>
           <ul className="mt-3 flex flex-col gap-2">
             {portfolio.technicalContributions?.map((item) => (
@@ -220,7 +241,10 @@ export default function PortfolioPreview({ portfolio, eyebrow }: PortfolioPrevie
       )}
 
       {(portfolio.codeHighlights?.length ?? 0) > 0 && (
-        <section className="rounded-lg border border-neutral-200 bg-white p-6">
+        <section
+          className="rounded-lg border border-neutral-200 bg-white p-6"
+          data-pdf-section="true"
+        >
           <span className="caption-m-sm text-neutral-400">코드/커밋 기반 근거</span>
           <ul className="mt-3 flex flex-col gap-2">
             {portfolio.codeHighlights?.map((item, i) => (


### PR DESCRIPTION
## 📌 개요

- **관련 이슈**: #68
- **작업 요약**: PDF 내보내기 3차 수정 - 섹션 단위 페이지 분할 및 링크 표시 개선

---
## 🔍 수정 내용

- 섹션(설명, 기술 스택, 주요 기능, 링크 등) 단위로 페이지 분할되어 내용이 중간에 잘리지 않도록 처리
- "관련 링크"를 "GitHub 링크"/"배포 링크"로 분리, 텍스트 스타일을 "주요 기능"과 동일하게 조정