### PR TITLE
fix: 회원가입 페이지들 헤더/푸터 스크롤 문제 수정

### DIFF
--- a/src/features/auth/components/AdditionalInfoForm.tsx
+++ b/src/features/auth/components/AdditionalInfoForm.tsx
@@ -45,30 +45,28 @@ export default function AdditionalInfoForm() {
   }
 
   return (
-    <div className="flex flex-col min-h-screen">
-      <div className="flex flex-col items-center justify-center flex-1">
-        <h1 className="title-bold mb-8">추가 정보 입력</h1>
-        <form onSubmit={handleSignup} className="flex flex-col gap-4 w-80">
-          <FormInput
-            type="text"
-            placeholder="닉네임 (포트폴리오 이름)"
-            value={name}
-            onChange={(e) => setName(e.target.value)}
-          />
-          <FormInput
-            type="text"
-            placeholder="한줄소개"
-            value={bio}
-            onChange={(e) => setBio(e.target.value)}
-          />
-          <button
-            type="submit"
-            className="bg-blue-500 text-white py-3 rounded-md body-m"
-          >
-            회원가입 완료
-          </button>
-        </form>
-      </div>
+    <div className="flex flex-col items-center justify-center">
+      <h1 className="title-bold mb-8">추가 정보 입력</h1>
+      <form onSubmit={handleSignup} className="flex flex-col gap-4 w-80">
+        <FormInput
+          type="text"
+          placeholder="닉네임 (포트폴리오 이름)"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+        />
+        <FormInput
+          type="text"
+          placeholder="한줄소개"
+          value={bio}
+          onChange={(e) => setBio(e.target.value)}
+        />
+        <button
+          type="submit"
+          className="bg-blue-500 text-white py-3 rounded-md body-m"
+        >
+          회원가입 완료
+        </button>
+      </form>
     </div>
   )
 }

--- a/src/features/auth/components/EmailSignupForm.tsx
+++ b/src/features/auth/components/EmailSignupForm.tsx
@@ -55,62 +55,60 @@ export default function EmailSignupForm() {
   }
 
   return (
-    <div className="flex flex-col min-h-screen">
-      <div className="flex flex-col items-center justify-center flex-1">
-        <h1 className="title-bold mb-8">이메일로 회원가입</h1>
-        <div className="flex flex-col gap-4 w-80">
-          <div className="flex gap-2">
-            <FormInput
-              type="email"
-              placeholder="이메일"
-              value={email}
-              onChange={(e) => setEmail(e.target.value)}
-            />
-            <button
-              type="button"
-              onClick={handleSendCode}
-              className="bg-blue-500 text-white px-3 py-2 rounded-md whitespace-nowrap"
-            >
-              인증번호 전송
-            </button>
-          </div>
-          {codeSent && (
-            <div className="flex gap-2">
-              <FormInput
-                type="text"
-                placeholder="인증번호"
-                value={code}
-                onChange={(e) => setCode(e.target.value)}
-              />
-              <button
-                type="button"
-                onClick={handleVerifyCode}
-                className="bg-blue-500 text-white px-3 py-2 rounded-md whitespace-nowrap"
-              >
-                확인
-              </button>
-            </div>
-          )}
+    <div className="flex flex-col items-center justify-center">
+      <h1 className="title-bold mb-8">이메일로 회원가입</h1>
+      <div className="flex flex-col gap-4 w-80">
+        <div className="flex gap-2">
           <FormInput
-            type="password"
-            placeholder="비밀번호"
-            value={password}
-            onChange={(e) => setPassword(e.target.value)}
-          />
-          <FormInput
-            type="password"
-            placeholder="비밀번호 확인"
-            value={passwordConfirm}
-            onChange={(e) => setPasswordConfirm(e.target.value)}
+            type="email"
+            placeholder="이메일"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
           />
           <button
             type="button"
-            onClick={handleNext}
-            className="bg-blue-500 text-white py-3 rounded-md body-m"
+            onClick={handleSendCode}
+            className="bg-blue-500 text-white px-3 py-2 rounded-md whitespace-nowrap"
           >
-            다음으로
+            인증번호 전송
           </button>
         </div>
+        {codeSent && (
+          <div className="flex gap-2">
+            <FormInput
+              type="text"
+              placeholder="인증번호"
+              value={code}
+              onChange={(e) => setCode(e.target.value)}
+            />
+            <button
+              type="button"
+              onClick={handleVerifyCode}
+              className="bg-blue-500 text-white px-3 py-2 rounded-md whitespace-nowrap"
+            >
+              확인
+            </button>
+          </div>
+        )}
+        <FormInput
+          type="password"
+          placeholder="비밀번호"
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+        />
+        <FormInput
+          type="password"
+          placeholder="비밀번호 확인"
+          value={passwordConfirm}
+          onChange={(e) => setPasswordConfirm(e.target.value)}
+        />
+        <button
+          type="button"
+          onClick={handleNext}
+          className="bg-blue-500 text-white py-3 rounded-md body-m"
+        >
+          다음으로
+        </button>
       </div>
     </div>
   )

--- a/src/features/auth/components/GithubSignupForm.tsx
+++ b/src/features/auth/components/GithubSignupForm.tsx
@@ -29,30 +29,28 @@ export default function GithubSignupForm() {
   }
 
   return (
-    <div className="flex flex-col min-h-screen">
-      <div className="flex flex-col items-center justify-center flex-1">
-        <h1 className="title-bold mb-8">추가 정보 입력</h1>
-        <form onSubmit={handleSignup} className="flex flex-col gap-4 w-80">
-          <FormInput
-            type="text"
-            placeholder="닉네임 (포트폴리오 이름)"
-            value={name}
-            onChange={(e) => setName(e.target.value)}
-          />
-          <FormInput
-            type="text"
-            placeholder="한줄소개"
-            value={bio}
-            onChange={(e) => setBio(e.target.value)}
-          />
-          <button
-            type="submit"
-            className="bg-blue-500 text-white py-3 rounded-md body-m"
-          >
-            회원가입 완료
-          </button>
-        </form>
-      </div>
+    <div className="flex flex-col items-center justify-center">
+      <h1 className="title-bold mb-8">추가 정보 입력</h1>
+      <form onSubmit={handleSignup} className="flex flex-col gap-4 w-80">
+        <FormInput
+          type="text"
+          placeholder="닉네임 (포트폴리오 이름)"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+        />
+        <FormInput
+          type="text"
+          placeholder="한줄소개"
+          value={bio}
+          onChange={(e) => setBio(e.target.value)}
+        />
+        <button
+          type="submit"
+          className="bg-blue-500 text-white py-3 rounded-md body-m"
+        >
+          회원가입 완료
+        </button>
+      </form>
     </div>
   )
 }

--- a/src/features/auth/components/SignupComplete.tsx
+++ b/src/features/auth/components/SignupComplete.tsx
@@ -7,17 +7,15 @@ export default function SignupComplete() {
   const router = useRouter()
 
   return (
-    <div className="flex flex-col min-h-screen">
-      <div className="flex flex-col items-center justify-center flex-1 gap-4">
-        <h1 className="title-bold">회원가입이 완료되었습니다!</h1>
-        <Image src="/octopus.svg" alt="" width={400} height={400} />
-        <button
-          onClick={() => router.push('/home')}
-          className="bg-blue-500 text-white py-3 px-6 rounded-md body-m"
-        >
-          포트폴리오 만들러 가기
-        </button>
-      </div>
+    <div className="flex flex-col items-center justify-center gap-4">
+      <h1 className="title-bold">회원가입이 완료되었습니다!</h1>
+      <Image src="/octopus.svg" alt="" width={400} height={400} />
+      <button
+        onClick={() => router.push('/home')}
+        className="bg-blue-500 text-white py-3 px-6 rounded-md body-m"
+      >
+        포트폴리오 만들러 가기
+      </button>
     </div>
   )
 }


### PR DESCRIPTION
## 📌 개요
- **관련 이슈**: #85
- **작업 요약**: 회원가입 흐름 페이지들의 헤더/푸터 스크롤 문제 수정

---
## 🔍 주요 구현 내용

### 1. 기능 설명
- `/signup/email`, `/signup/info`, `/signup/complete` 등 회원가입 흐름 페이지에서 헤더/푸터가 화면 밖으로 밀려 스크롤해야 보이던 문제 수정