### PR TITLE
[Fix] 포트폴리오 주요 기능 수정 필드 불일치 해결

### DIFF
--- a/src/features/portfolio/components/PortfolioEditPage.tsx
+++ b/src/features/portfolio/components/PortfolioEditPage.tsx
@@ -21,22 +21,33 @@ function ProjectEditor({
   onSetFeatured: () => void
 }) {
   const [rawTechStacks, setRawTechStacks] = useState(() => (project.techStacks ?? []).join(', '))
-  const [rawHighlights, setRawHighlights] = useState(() => (project.highlights ?? []).join(', '))
+  const [rawMainFeatures, setRawMainFeatures] = useState(() =>
+    (project.mainFeatures ?? project.highlights ?? []).join(', '),
+  )
 
   useEffect(() => {
     setRawTechStacks((project.techStacks ?? []).join(', '))
   }, [project.repoId])
 
   useEffect(() => {
-    setRawHighlights((project.highlights ?? []).join(', '))
+    setRawMainFeatures((project.mainFeatures ?? project.highlights ?? []).join(', '))
   }, [project.repoId])
+
+  const features = project.mainFeatures ?? project.highlights ?? []
 
   function update<K extends keyof Project>(key: K, value: Project[K]) {
     onChange({ ...project, [key]: value })
   }
 
-  function handleArrayInput(key: 'techStacks' | 'highlights', raw: string) {
-    update(key, raw.split(',').map((s) => s.trim()).filter(Boolean))
+  function handleArrayInput(key: 'techStacks' | 'mainFeatures', raw: string) {
+    const values = raw.split(',').map((s) => s.trim()).filter(Boolean)
+
+    if (key === 'mainFeatures') {
+      onChange({ ...project, mainFeatures: values, highlights: values })
+      return
+    }
+
+    update(key, values)
   }
 
   return (
@@ -126,18 +137,18 @@ function ProjectEditor({
             주요 기능 <span className="text-neutral-300">(쉼표로 구분)</span>
           </span>
           <textarea
-            value={rawHighlights}
-            onChange={(e) => { setRawHighlights(e.target.value); handleArrayInput('highlights', e.target.value) }}
+            value={rawMainFeatures}
+            onChange={(e) => { setRawMainFeatures(e.target.value); handleArrayInput('mainFeatures', e.target.value) }}
             placeholder="GitHub OAuth 로그인, Gemini 기반 생성"
             rows={3}
             className="body-m mt-1 w-full rounded-xl border border-neutral-200 bg-neutral-50 px-4 py-3 text-neutral-700 focus:outline-none focus:border-neutral-400 resize-none"
           />
-          {(project.highlights ?? []).length > 0 && (
+          {features.length > 0 && (
             <ul className="mt-2 flex flex-col gap-1.5">
-              {project.highlights!.map((h, i) => (
+              {features.map((feature, i) => (
                 <li key={i} className="body-m flex gap-2 text-neutral-700">
                   <span className="mt-1.5 h-1.5 w-1.5 shrink-0 rounded-full bg-emerald-400" />
-                  {h}
+                  {feature}
                 </li>
               ))}
             </ul>
@@ -171,6 +182,11 @@ export default function PortfolioEditPage({ portfolioId }: { portfolioId: number
       bio: portfolio.bio ?? '',
       summary: portfolio.summary ?? '',
       description: portfolio.description ?? '',
+      technicalContributions: portfolio.technicalContributions ?? [],
+      codeHighlights: portfolio.codeHighlights ?? [],
+      projectLinks: portfolio.projectLinks ?? [],
+      generatedAt: portfolio.generatedAt,
+      templateId: portfolio.templateId,
       projects: portfolio.projects ?? [],
       isPublic: portfolio.isPublic,
     })

--- a/src/types/portfolio.ts
+++ b/src/types/portfolio.ts
@@ -49,6 +49,10 @@ export interface UpdatePortfolioRequest {
   bio: string
   summary?: string
   description?: string
+  technicalContributions?: string[]
+  codeHighlights?: string[]
+  projectLinks?: string[]
+  generatedAt?: string
   templateId?: number
   featuredProjectId?: number
   projects: Project[]


### PR DESCRIPTION
## 📌 개요

- **관련 이슈**: Closes #87 
- **작업 요약**: 무엇을 위한 작업인지 한 줄로 설명해주세요.

---
## 작업 내용

- 포트폴리오 편집 화면에서 프로젝트 주요 기능 수정 시 `highlights`가 아닌 `mainFeatures`에 반영되도록 수정했습니다.
- 기존 데이터가 `highlights`에만 있는 경우도 편집 화면에서 표시될 수 있도록 fallback을 유지했습니다.
- 저장 시 `mainFeatures`와 `highlights`를 함께 동기화해 API request body와 상세 조회 응답 간 불일치를 방지했습니다.
- 수정 API body에 포함되는 최상위 필드(`technicalContributions`, `codeHighlights`, `projectLinks`, `generatedAt`, `templateId`)가 저장 과정에서 누락되지 않도록 기존 값을 보존했습니다.

---

## 문제 원인

마이페이지 상세 화면은 `projects[].mainFeatures`를 렌더링하고 있었지만, 편집 화면에서는 주요 기능 값을 `projects[].highlights`에 저장하고 있었습니다.

이로 인해 수정 후 다시 상세 조회를 해도 상세 화면에서는 기존 `mainFeatures`를 보여주어 수정 내용이 반영되지 않은 것처럼 보였습니다.

---

## 확인 사항

- 포트폴리오 편집 화면에서 주요 기능 입력값이 `mainFeatures`에 반영되도록 수정
- 상세 화면 렌더링 기준 필드와 편집 저장 필드 일치
- 수정 API request body 타입 보강
