### PR TITLE
fix: 마이페이지 카드 제목 featuredProjectName 폴백 제거

### DIFF
--- a/src/app/home/my/page.tsx
+++ b/src/app/home/my/page.tsx
@@ -224,7 +224,7 @@ const MyPage = () => {
                     </div>
                     <div>
                       <h3 className="body-sb line-clamp-2 text-neutral-950">
-                        {portfolio.featuredProjectName ?? portfolio.title}
+                        {portfolio.title}
                       </h3>
                       <p className="body-m mt-2 line-clamp-3 whitespace-pre-line text-neutral-500">
                         {portfolio.summary || portfolio.description || '프로젝트 요약이 아직 없어요.'}


### PR DESCRIPTION
## 📌 개요

- **관련 이슈**: #89
- **작업 요약**: 마이페이지 카드 제목 표시 방식 수정

---
## 🔍 수정 내용

- `featuredProjectName ?? title` → `title`로 변경
- `featuredProjectName`이 포트폴리오 수정(PUT) 후 null로 바뀌는 백엔드 이슈로 인해 카드 제목이 생성 직후와 수정 후 다르게 표시되는 문제 해결